### PR TITLE
Add initial nftnl abstraction

### DIFF
--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -14,4 +14,6 @@ nftnl-1-0-8 = ["nftnl-sys/nftnl-1-0-8"]
 nftnl-1-0-9 = ["nftnl-sys/nftnl-1-0-9"]
 
 [dependencies]
+error-chain = "0.11"
+libc = "0.2.40"
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/mullvad/nftnl-rs"
 keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "api-bindings"]
 
+[features]
+nftnl-1-0-7 = ["nftnl-sys/nftnl-1-0-7"]
+nftnl-1-0-8 = ["nftnl-sys/nftnl-1-0-8"]
+nftnl-1-0-9 = ["nftnl-sys/nftnl-1-0-9"]
 
 [dependencies]
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,0 +1,103 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use std::ffi::CStr;
+
+use Table;
+use {ErrorKind, MsgType, Result};
+
+
+pub type Priority = u32;
+
+/// The netfilter event hooks a chain can register for.
+#[derive(Debug, Copy, Clone)]
+#[repr(u16)]
+pub enum Hook {
+    PreRouting = libc::NF_INET_PRE_ROUTING as u16,
+    In = libc::NF_INET_LOCAL_IN as u16,
+    Forward = libc::NF_INET_FORWARD as u16,
+    Out = libc::NF_INET_LOCAL_OUT as u16,
+    PostRouting = libc::NF_INET_POST_ROUTING as u16,
+}
+
+/// Abstraction of a `nftnl_chain`. Chains reside inside [`Table`]s and they hold `Rule`s.
+///
+/// There are two types of chains, "base chain" and "regular chain". See [`set_hook`] for more
+/// details.
+///
+/// [`Table`]: struct.Table.html
+/// [`set_hook`]: #method.set_hook
+pub struct Chain<'a> {
+    chain: *mut sys::nftnl_chain,
+    table: &'a Table,
+}
+
+impl<'a> Chain<'a> {
+    /// Creates a new chain instance inside the given [`Table`] and with the given name.
+    ///
+    /// [`Table`]: struct.Table.html
+    pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Result<Chain<'a>> {
+        unsafe {
+            let chain = sys::nftnl_chain_alloc();
+            if chain.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+
+            sys::nftnl_chain_set_str(
+                chain,
+                sys::NFTNL_CHAIN_TABLE as u16,
+                table.get_name().as_ptr(),
+            );
+            sys::nftnl_chain_set_str(chain, sys::NFTNL_CHAIN_NAME as u16, name.as_ref().as_ptr());
+            Ok(Chain { chain, table })
+        }
+    }
+
+    /// Sets the hook and priority for this chain. Without calling this method the chain well
+    /// become a "regular chain" without any hook and will thus not receive any traffic unless
+    /// some rule forward packets to it via goto or jump verdicts.
+    ///
+    /// By calling `set_hook` with a hook the chain that is created will be registered with that
+    /// hook and is thus a "base chain". A "base chain" is an entry point for packets from the
+    /// networking stack.
+    pub fn set_hook(&mut self, hook: Hook, priority: Priority) {
+        unsafe {
+            sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_HOOKNUM as u16, hook as u32);
+            sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_PRIO as u16, priority);
+        }
+    }
+
+    pub fn get_name(&self) -> &CStr {
+        unsafe {
+            let ptr = sys::nftnl_chain_get_str(self.chain, sys::NFTNL_CHAIN_NAME as u16);
+            CStr::from_ptr(ptr)
+        }
+    }
+
+    pub fn get_table(&self) -> &Table {
+        self.table
+    }
+}
+
+unsafe impl<'a> ::NlMsg for Chain<'a> {
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
+        let raw_msg_type = match msg_type {
+            MsgType::Add => libc::NFT_MSG_NEWCHAIN,
+            MsgType::Del => libc::NFT_MSG_DELCHAIN,
+        };
+        let header = sys::nftnl_nlmsg_build_hdr(
+            buf as *mut i8,
+            raw_msg_type as u16,
+            self.table.get_family() as u16,
+            libc::NLM_F_ACK as u16,
+            seq,
+        );
+        sys::nftnl_chain_nlmsg_build_payload(header, self.chain);
+    }
+}
+
+impl<'a> Drop for Chain<'a> {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_chain_free(self.chain) };
+    }
+}

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -1,0 +1,64 @@
+pub extern crate nftnl_sys;
+
+#[macro_use]
+extern crate error_chain;
+extern crate libc;
+
+use nftnl_sys::c_void;
+
+error_chain! {
+    errors {
+        AllocationError { description("Unable to allocate memory") }
+    }
+}
+
+
+mod table;
+pub use table::Table;
+
+mod chain;
+pub use chain::{Chain, Hook, Priority};
+
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum MsgType {
+    Add,
+    Del,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u16)]
+pub enum ProtoFamily {
+    Unspec = libc::NFPROTO_UNSPEC as u16,
+    Inet = libc::NFPROTO_INET as u16,
+    Ipv4 = libc::NFPROTO_IPV4 as u16,
+    Arp = libc::NFPROTO_ARP as u16,
+    NetDev = libc::NFPROTO_NETDEV as u16,
+    Bridge = libc::NFPROTO_BRIDGE as u16,
+    Ipv6 = libc::NFPROTO_IPV6 as u16,
+    DecNet = libc::NFPROTO_DECNET as u16,
+}
+
+/// Trait for all types in this crate that can serialize to a Netlink message.
+///
+/// # Unsafe
+///
+/// This trait is unsafe to implement because it must never serialize to anything larger than the
+/// largest possible netlink message. Internally the `nft_nlmsg_maxsize()` function is used to make
+/// sure the `buf` pointer passed to `write` always has room for the largest possible Netlink
+/// message.
+pub unsafe trait NlMsg {
+    /// Serializes the Netlink message to the buffer at `buf`. `buf` must have space for at least
+    /// `nft_nlmsg_maxsize()` bytes. This is not checked by the compiler, which is why this method
+    /// is unsafe.
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType);
+}
+
+/// The largest nf_tables netlink message is the set element message, which
+/// contains the NFTA_SET_ELEM_LIST_ELEMENTS attribute. This attribute is
+/// a nest that describes the set elements. Given that the netlink attribute
+/// length (nla_len) is 16 bits, the largest message is a bit larger than
+/// 64 KBytes.
+pub fn nft_nlmsg_maxsize() -> u32 {
+    ::std::u16::MAX as u32 + unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32
+}

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -1,0 +1,66 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use std::ffi::CStr;
+
+use {ErrorKind, MsgType, ProtoFamily, Result};
+
+
+/// Abstraction of `nftnl_table`. The top level container in netfilter. A table has a protocol
+/// family and contain [`Chain`]s that in turn hold the rules.
+///
+/// [`Chain`]: struct.Chain.html
+pub struct Table {
+    table: *mut sys::nftnl_table,
+    family: ProtoFamily,
+}
+
+impl Table {
+    /// Creates a new table instance with the given name and protocol family.
+    pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Result<Table> {
+        unsafe {
+            let table = sys::nftnl_table_alloc();
+            if table.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+
+            sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
+            sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FAMILY as u16, family as u32);
+            Ok(Table { table, family })
+        }
+    }
+
+    pub fn get_name(&self) -> &CStr {
+        unsafe {
+            let ptr = sys::nftnl_table_get_str(self.table, sys::NFTNL_TABLE_NAME as u16);
+            CStr::from_ptr(ptr)
+        }
+    }
+
+    pub fn get_family(&self) -> ProtoFamily {
+        self.family
+    }
+}
+
+unsafe impl ::NlMsg for Table {
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
+        let raw_msg_type = match msg_type {
+            MsgType::Add => libc::NFT_MSG_NEWTABLE,
+            MsgType::Del => libc::NFT_MSG_DELTABLE,
+        };
+        let header = sys::nftnl_nlmsg_build_hdr(
+            buf as *mut i8,
+            raw_msg_type as u16,
+            self.family as u16,
+            libc::NLM_F_ACK as u16,
+            seq,
+        );
+        sys::nftnl_table_nlmsg_build_payload(header, self.table);
+    }
+}
+
+impl Drop for Table {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_table_free(self.table) };
+    }
+}


### PR DESCRIPTION
Here comes the first batch of code for the higher level `nftnl` crate that should safely wrap `nftnl-sys`. This contains the top level objects `Table` and `Chain`. In nftables/netfiler the structure is the following basically:
```
tables
    |-> sets (used to store a collection of items to compare against, such as a list of IPs)
    \-> chains
         \-> rules
              |-> expressions ("tcp dport 80" etc)
              \-> verdict (accept, drop etc)
```
One can read https://wiki.archlinux.org/index.php/Nftables for more details.

Rules, sets and expressions will come an later PRs. But they more or less follow the same design at the moment, so good to understand this small subset and argue about if it has problems or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/3)
<!-- Reviewable:end -->
