### PR TITLE
Add rule and exprs

### DIFF
--- a/nftnl-sys/src/lib.rs
+++ b/nftnl-sys/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! Low level FFI bindings to [`libnftnl`]. a userspace library providing a low-level netlink
 //! programming interface (API) to the in-kernel nf_tables subsystem.
-//! 
+//!
 //! See [`nftnl`] for a higher level safe abstraction.
 //!
 //! [`libnftnl`]: https://netfilter.org/projects/libnftnl/

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -16,4 +16,5 @@ nftnl-1-0-9 = ["nftnl-sys/nftnl-1-0-9"]
 [dependencies]
 error-chain = "0.11"
 libc = "0.2.40"
+log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -1,10 +1,10 @@
 use libc;
-use nftnl_sys::{self as sys, c_void};
+use nftnl_sys::{self as sys, c_char, c_void};
 
 use std::borrow::Cow;
 use std::ffi::CString;
-use std::slice;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::slice;
 
 use super::Expression;
 use {ErrorKind, Result};
@@ -58,7 +58,7 @@ impl<T: ToSlice> Cmp<T> {
 impl<T: ToSlice> Expression for Cmp<T> {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const i8);
+            let expr = sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const c_char);
             if expr.is_null() {
                 bail!(ErrorKind::AllocationError);
             }

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -1,0 +1,223 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use std::borrow::Cow;
+use std::ffi::CString;
+use std::slice;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use super::Expression;
+use {ErrorKind, Result};
+
+/// Comparison operator.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum CmpOp {
+    /// Equals.
+    Eq,
+    /// Not equal.
+    Neq,
+    /// Less than.
+    Lt,
+    /// Less than, or equal.
+    Lte,
+    /// Greater than.
+    Gt,
+    /// Greater than, or equal.
+    Gte,
+}
+
+impl CmpOp {
+    pub fn to_raw(&self) -> u32 {
+        use self::CmpOp::*;
+        match *self {
+            Eq => libc::NFT_CMP_EQ as u32,
+            Neq => libc::NFT_CMP_NEQ as u32,
+            Lt => libc::NFT_CMP_LT as u32,
+            Lte => libc::NFT_CMP_LTE as u32,
+            Gt => libc::NFT_CMP_GT as u32,
+            Gte => libc::NFT_CMP_GTE as u32,
+        }
+    }
+}
+
+
+/// Comparator expression. Allows comparing the content of the netfilter register with any value.
+pub struct Cmp<T: ToSlice> {
+    op: CmpOp,
+    data: T,
+}
+
+impl<T: ToSlice> Cmp<T> {
+    /// Returns a new comparison expression comparing the value loaded in the register with the
+    /// data in `data` using the comparison operator `op`.
+    pub fn new(op: CmpOp, data: T) -> Self {
+        Cmp { op, data }
+    }
+}
+
+impl<T: ToSlice> Expression for Cmp<T> {
+    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+        unsafe {
+            let expr = sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const i8);
+            if expr.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+
+            let data = self.data.to_slice();
+            trace!("Creating a cmp expr comparing with data {:?}", data);
+
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_CMP_SREG as u16,
+                libc::NFT_REG_1 as u32,
+            );
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CMP_OP as u16, self.op.to_raw());
+            sys::nftnl_expr_set(
+                expr,
+                sys::NFTNL_EXPR_CMP_DATA as u16,
+                data.as_ref() as *const _ as *const c_void,
+                data.len() as u32,
+            );
+
+            Ok(expr)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_cmp {
+    (==) => {
+        $crate::expr::CmpOp::Eq
+    };
+    (!=) => {
+        $crate::expr::CmpOp::Neq
+    };
+    (<) => {
+        $crate::expr::CmpOp::Lt
+    };
+    (<=) => {
+        $crate::expr::CmpOp::Lte
+    };
+    (>) => {
+        $crate::expr::CmpOp::Gt
+    };
+    (>=) => {
+        $crate::expr::CmpOp::Gte
+    };
+    ($op:tt $data:expr) => {
+        $crate::expr::Cmp::new(nft_expr_cmp!($op), $data)
+    };
+}
+
+
+/// A type that can be converted into a byte buffer.
+pub trait ToSlice {
+    /// Returns the data this type represents.
+    fn to_slice(&self) -> Cow<[u8]>;
+}
+
+impl<'a> ToSlice for [u8; 0] {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&[])
+    }
+}
+
+impl<'a> ToSlice for &'a [u8] {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl<'a> ToSlice for &'a [u16] {
+    fn to_slice(&self) -> Cow<[u8]> {
+        let ptr = self.as_ptr() as *const u8;
+        let len = self.len() * 2;
+        Cow::Borrowed(unsafe { slice::from_raw_parts(ptr, len) })
+    }
+}
+
+impl ToSlice for IpAddr {
+    fn to_slice(&self) -> Cow<[u8]> {
+        match *self {
+            IpAddr::V4(ref addr) => addr.to_slice(),
+            IpAddr::V6(ref addr) => addr.to_slice(),
+        }
+    }
+}
+
+impl ToSlice for Ipv4Addr {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::Owned(self.octets().to_vec())
+    }
+}
+
+impl ToSlice for Ipv6Addr {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::Owned(self.octets().to_vec())
+    }
+}
+
+impl ToSlice for u8 {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::Owned(vec![*self])
+    }
+}
+
+impl ToSlice for u16 {
+    fn to_slice(&self) -> Cow<[u8]> {
+        let b0 = (*self & 0x00ff) as u8;
+        let b1 = (*self >> 8) as u8;
+        Cow::Owned(vec![b0, b1])
+    }
+}
+
+impl ToSlice for u32 {
+    fn to_slice(&self) -> Cow<[u8]> {
+        let b0 = *self as u8;
+        let b1 = (*self >> 8) as u8;
+        let b2 = (*self >> 16) as u8;
+        let b3 = (*self >> 24) as u8;
+        Cow::Owned(vec![b0, b1, b2, b3])
+    }
+}
+
+impl ToSlice for i32 {
+    fn to_slice(&self) -> Cow<[u8]> {
+        let b0 = *self as u8;
+        let b1 = (*self >> 8) as u8;
+        let b2 = (*self >> 16) as u8;
+        let b3 = (*self >> 24) as u8;
+        Cow::Owned(vec![b0, b1, b2, b3])
+    }
+}
+
+impl<'a> ToSlice for &'a str {
+    fn to_slice(&self) -> Cow<[u8]> {
+        Cow::from(self.as_bytes())
+    }
+}
+
+/// Can be used to compare the value loaded by [`Meta::IifName`] and [`Meta::OifName`]. Please
+/// note that it is faster to check interface index than name.
+///
+/// [`Meta::IifName`]: enum.Meta.html#variant.IifName
+/// [`Meta::OifName`]: enum.Meta.html#variant.OifName
+pub enum InterfaceName {
+    /// Interface name must be exactly the value of the `CString`.
+    Exact(CString),
+    /// Interface name must start with the value of the `CString`.
+    ///
+    /// `InterfaceName::StartingWith("eth")` will look like `eth*` when printed and match against
+    /// `eth0`, `eth1`, ..., `eth99` and so on.
+    StartingWith(CString),
+}
+
+impl<'a> ToSlice for InterfaceName {
+    fn to_slice(&self) -> Cow<[u8]> {
+        let bytes = match *self {
+            InterfaceName::Exact(ref name) => name.as_bytes_with_nul(),
+            InterfaceName::StartingWith(ref name) => name.as_bytes(),
+        };
+        Cow::from(bytes)
+    }
+}

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -86,26 +86,26 @@ impl<T: ToSlice> Expression for Cmp<T> {
 
 #[macro_export]
 macro_rules! nft_expr_cmp {
-    (==) => {
+    (@cmp_op ==) => {
         $crate::expr::CmpOp::Eq
     };
-    (!=) => {
+    (@cmp_op !=) => {
         $crate::expr::CmpOp::Neq
     };
-    (<) => {
+    (@cmp_op <) => {
         $crate::expr::CmpOp::Lt
     };
-    (<=) => {
+    (@cmp_op <=) => {
         $crate::expr::CmpOp::Lte
     };
-    (>) => {
+    (@cmp_op >) => {
         $crate::expr::CmpOp::Gt
     };
-    (>=) => {
+    (@cmp_op >=) => {
         $crate::expr::CmpOp::Gte
     };
     ($op:tt $data:expr) => {
-        $crate::expr::Cmp::new(nft_expr_cmp!($op), $data)
+        $crate::expr::Cmp::new(nft_expr_cmp!(@cmp_op $op), $data)
     };
 }
 

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -17,10 +17,3 @@ impl Expression for Counter {
         }
     }
 }
-
-#[macro_export]
-macro_rules! nft_expr_counter {
-    () => {
-        $crate::expr::Counter
-    };
-}

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -1,5 +1,5 @@
 use super::Expression;
-use nftnl_sys as sys;
+use nftnl_sys::{self as sys, c_char};
 use {ErrorKind, Result};
 
 /// A counter expression adds a counter to the rule that is incremented to count number of packets
@@ -9,7 +9,7 @@ pub struct Counter;
 impl Expression for Counter {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const i8);
+            let expr = sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char);
             if expr.is_null() {
                 bail!(ErrorKind::AllocationError);
             }

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -1,0 +1,26 @@
+use super::Expression;
+use nftnl_sys as sys;
+use {ErrorKind, Result};
+
+/// A counter expression adds a counter to the rule that is incremented to count number of packets
+/// and number of bytes for all packets that has matched the rule.
+pub struct Counter;
+
+impl Expression for Counter {
+    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+        unsafe {
+            let expr = sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const i8);
+            if expr.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+            Ok(expr)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_counter {
+    () => {
+        $crate::expr::Counter
+    };
+}

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -1,0 +1,81 @@
+use libc;
+use nftnl_sys as sys;
+
+use super::Expression;
+use {ErrorKind, Result};
+
+/// A meta expression refers to meta data associated with a packet.
+pub enum Meta {
+    /// Ethertype protocol value.
+    Protocol,
+    /// Input interface index.
+    Iif,
+    /// Output interface index.
+    Oif,
+    /// Input interface name.
+    IifName,
+    /// Output interface name.
+    OifName,
+    /// Transport layer protocol.
+    NfProto,
+    /// Layer4 protocol.
+    L4Proto,
+}
+
+impl Meta {
+    pub fn to_raw_key(&self) -> u32 {
+        use self::Meta::*;
+        match *self {
+            Protocol => libc::NFT_META_PROTOCOL as u32,
+            Iif => libc::NFT_META_IIF as u32,
+            Oif => libc::NFT_META_OIF as u32,
+            IifName => libc::NFT_META_IIFNAME as u32,
+            OifName => libc::NFT_META_OIFNAME as u32,
+            NfProto => libc::NFT_META_NFPROTO as u32,
+            L4Proto => libc::NFT_META_L4PROTO as u32,
+        }
+    }
+}
+
+impl Expression for Meta {
+    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+        unsafe {
+            let expr = sys::nftnl_expr_alloc(b"meta\0" as *const _ as *const i8);
+            if expr.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_META_DREG as u16,
+                libc::NFT_REG_1 as u32,
+            );
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_META_KEY as u16, self.to_raw_key());
+            Ok(expr)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_meta {
+    (proto) => {
+        $crate::expr::Meta::Protocol
+    };
+    (iif) => {
+        $crate::expr::Meta::Iif
+    };
+    (oif) => {
+        $crate::expr::Meta::Oif
+    };
+    (iifname) => {
+        $crate::expr::Meta::IifName
+    };
+    (oifname) => {
+        $crate::expr::Meta::OifName
+    };
+    (nfproto) => {
+        $crate::expr::Meta::NfProto
+    };
+    (l4proto) => {
+        $crate::expr::Meta::L4Proto
+    };
+}

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -1,5 +1,5 @@
 use libc;
-use nftnl_sys as sys;
+use nftnl_sys::{self as sys, c_char};
 
 use super::Expression;
 use {ErrorKind, Result};
@@ -40,7 +40,7 @@ impl Meta {
 impl Expression for Meta {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"meta\0" as *const _ as *const i8);
+            let expr = sys::nftnl_expr_alloc(b"meta\0" as *const _ as *const c_char);
             if expr.is_null() {
                 bail!(ErrorKind::AllocationError);
             }

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -24,7 +24,7 @@ macro_rules! nft_expr {
         nft_expr_cmp!($op $data)
     };
     (counter) => {
-        nft_expr_counter!()
+        $crate::expr::Counter
     };
     (meta $expr:ident) => {
         nft_expr_meta!($expr)

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -1,0 +1,35 @@
+use nftnl_sys as sys;
+
+use Result;
+
+pub trait Expression {
+    fn to_expr(&self) -> Result<*mut sys::nftnl_expr>;
+}
+
+mod cmp;
+pub use self::cmp::*;
+
+mod counter;
+pub use self::counter::*;
+
+mod meta;
+pub use self::meta::*;
+
+mod payload;
+pub use self::payload::*;
+
+#[macro_export]
+macro_rules! nft_expr {
+    (cmp $op:tt $data:expr) => {
+        nft_expr_cmp!($op $data)
+    };
+    (counter) => {
+        nft_expr_counter!()
+    };
+    (meta $expr:ident) => {
+        nft_expr_meta!($expr)
+    };
+    (payload $proto:ident $field:ident) => {
+        nft_expr_payload!($proto $field)
+    };
+}

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -99,39 +99,39 @@ impl Expression for Payload {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum NetworkHeaderField {
-    Ip(IpHeaderField),
-    Ip6(Ip6HeaderField),
+    Ipv4(Ipv4HeaderField),
+    Ipv6(Ipv6HeaderField),
 }
 
 impl HeaderField for NetworkHeaderField {
     fn offset(&self) -> u32 {
         use self::NetworkHeaderField::*;
         match *self {
-            Ip(ref f) => f.offset(),
-            Ip6(ref f) => f.offset(),
+            Ipv4(ref f) => f.offset(),
+            Ipv6(ref f) => f.offset(),
         }
     }
 
     fn len(&self) -> u32 {
         use self::NetworkHeaderField::*;
         match *self {
-            Ip(ref f) => f.len(),
-            Ip6(ref f) => f.len(),
+            Ipv4(ref f) => f.len(),
+            Ipv6(ref f) => f.len(),
         }
     }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum IpHeaderField {
+pub enum Ipv4HeaderField {
     Ttl,
     Protocol,
     Saddr,
     Daddr,
 }
 
-impl HeaderField for IpHeaderField {
+impl HeaderField for Ipv4HeaderField {
     fn offset(&self) -> u32 {
-        use self::IpHeaderField::*;
+        use self::Ipv4HeaderField::*;
         match *self {
             Ttl => 8,
             Protocol => 9,
@@ -141,7 +141,7 @@ impl HeaderField for IpHeaderField {
     }
 
     fn len(&self) -> u32 {
-        use self::IpHeaderField::*;
+        use self::Ipv4HeaderField::*;
         match *self {
             Ttl => 1,
             Protocol => 1,
@@ -152,16 +152,16 @@ impl HeaderField for IpHeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum Ip6HeaderField {
+pub enum Ipv6HeaderField {
     NextHeader,
     HopLimit,
     Saddr,
     Daddr,
 }
 
-impl HeaderField for Ip6HeaderField {
+impl HeaderField for Ipv6HeaderField {
     fn offset(&self) -> u32 {
-        use self::Ip6HeaderField::*;
+        use self::Ipv6HeaderField::*;
         match *self {
             NextHeader => 6,
             HopLimit => 7,
@@ -171,7 +171,7 @@ impl HeaderField for Ip6HeaderField {
     }
 
     fn len(&self) -> u32 {
-        use self::Ip6HeaderField::*;
+        use self::Ipv6HeaderField::*;
         match *self {
             NextHeader => 1,
             HopLimit => 1,
@@ -258,40 +258,40 @@ impl HeaderField for UdpHeaderField {
 
 #[macro_export]
 macro_rules! nft_expr_payload {
-    (ip_field ttl) => {
-        $crate::expr::IpHeaderField::Ttl
+    (ipv4_field ttl) => {
+        $crate::expr::Ipv4HeaderField::Ttl
     };
-    (ip_field protocol) => {
-        $crate::expr::IpHeaderField::Protocol
+    (ipv4_field protocol) => {
+        $crate::expr::Ipv4HeaderField::Protocol
     };
-    (ip_field saddr) => {
-        $crate::expr::IpHeaderField::Saddr
+    (ipv4_field saddr) => {
+        $crate::expr::Ipv4HeaderField::Saddr
     };
-    (ip_field daddr) => {
-        $crate::expr::IpHeaderField::Daddr
-    };
-
-    (ip6_field nextheader) => {
-        $crate::expr::Ip6HeaderField::NextHeader
-    };
-    (ip6_field hoplimit) => {
-        $crate::expr::Ip6HeaderField::HopLimit
-    };
-    (ip6_field saddr) => {
-        $crate::expr::Ip6HeaderField::Saddr
-    };
-    (ip6_field daddr) => {
-        $crate::expr::Ip6HeaderField::Daddr
+    (ipv4_field daddr) => {
+        $crate::expr::Ipv4HeaderField::Daddr
     };
 
-    (ip $field:ident) => {
-        $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ip(
-            nft_expr_payload!(ip_field $field),
+    (ipv6_field nextheader) => {
+        $crate::expr::Ipv6HeaderField::NextHeader
+    };
+    (ipv6_field hoplimit) => {
+        $crate::expr::Ipv6HeaderField::HopLimit
+    };
+    (ipv6_field saddr) => {
+        $crate::expr::Ipv6HeaderField::Saddr
+    };
+    (ipv6_field daddr) => {
+        $crate::expr::Ipv6HeaderField::Daddr
+    };
+
+    (ipv4 $field:ident) => {
+        $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ipv4(
+            nft_expr_payload!(ipv4_field $field),
         ))
     };
-    (ip6 $field:ident) => {
-        $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ip6(
-            nft_expr_payload!(ip6_field $field),
+    (ipv6 $field:ident) => {
+        $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ipv6(
+            nft_expr_payload!(ipv6_field $field),
         ))
     };
 

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -1,5 +1,5 @@
 use libc;
-use nftnl_sys as sys;
+use nftnl_sys::{self as sys, c_char};
 
 use super::Expression;
 use {ErrorKind, Result};
@@ -51,7 +51,7 @@ impl HeaderField for Payload {
 impl Expression for Payload {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"payload\0" as *const _ as *const i8);
+            let expr = sys::nftnl_expr_alloc(b"payload\0" as *const _ as *const c_char);
             if expr.is_null() {
                 bail!(ErrorKind::AllocationError);
             }

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -258,68 +258,68 @@ impl HeaderField for UdpHeaderField {
 
 #[macro_export]
 macro_rules! nft_expr_payload {
-    (ipv4_field ttl) => {
+    (@ipv4_field ttl) => {
         $crate::expr::Ipv4HeaderField::Ttl
     };
-    (ipv4_field protocol) => {
+    (@ipv4_field protocol) => {
         $crate::expr::Ipv4HeaderField::Protocol
     };
-    (ipv4_field saddr) => {
+    (@ipv4_field saddr) => {
         $crate::expr::Ipv4HeaderField::Saddr
     };
-    (ipv4_field daddr) => {
+    (@ipv4_field daddr) => {
         $crate::expr::Ipv4HeaderField::Daddr
     };
 
-    (ipv6_field nextheader) => {
+    (@ipv6_field nextheader) => {
         $crate::expr::Ipv6HeaderField::NextHeader
     };
-    (ipv6_field hoplimit) => {
+    (@ipv6_field hoplimit) => {
         $crate::expr::Ipv6HeaderField::HopLimit
     };
-    (ipv6_field saddr) => {
+    (@ipv6_field saddr) => {
         $crate::expr::Ipv6HeaderField::Saddr
     };
-    (ipv6_field daddr) => {
+    (@ipv6_field daddr) => {
         $crate::expr::Ipv6HeaderField::Daddr
+    };
+
+    (@tcp_field sport) => {
+        $crate::expr::TcpHeaderField::Sport
+    };
+    (@tcp_field dport) => {
+        $crate::expr::TcpHeaderField::Dport
+    };
+
+    (@udp_field sport) => {
+        $crate::expr::UdpHeaderField::Sport
+    };
+    (@udp_field dport) => {
+        $crate::expr::UdpHeaderField::Dport
+    };
+    (@udp_field len) => {
+        $crate::expr::UdpHeaderField::Len
     };
 
     (ipv4 $field:ident) => {
         $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ipv4(
-            nft_expr_payload!(ipv4_field $field),
+            nft_expr_payload!(@ipv4_field $field),
         ))
     };
     (ipv6 $field:ident) => {
         $crate::expr::Payload::Network($crate::expr::NetworkHeaderField::Ipv6(
-            nft_expr_payload!(ipv6_field $field),
+            nft_expr_payload!(@ipv6_field $field),
         ))
-    };
-
-    (tcp_field sport) => {
-        $crate::expr::TcpHeaderField::Sport
-    };
-    (tcp_field dport) => {
-        $crate::expr::TcpHeaderField::Dport
-    };
-
-    (udp_field sport) => {
-        $crate::expr::UdpHeaderField::Sport
-    };
-    (udp_field dport) => {
-        $crate::expr::UdpHeaderField::Dport
-    };
-    (udp_field len) => {
-        $crate::expr::UdpHeaderField::Len
     };
 
     (tcp $field:ident) => {
         $crate::expr::Payload::Transport($crate::expr::TransportHeaderField::Tcp(
-            nft_expr_payload!(tcp_field $field),
+            nft_expr_payload!(@tcp_field $field),
         ))
     };
     (udp $field:ident) => {
         $crate::expr::Payload::Transport($crate::expr::TransportHeaderField::Udp(
-            nft_expr_payload!(udp_field $field),
+            nft_expr_payload!(@udp_field $field),
         ))
     };
 }

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -3,6 +3,8 @@ pub extern crate nftnl_sys;
 #[macro_use]
 extern crate error_chain;
 extern crate libc;
+#[macro_use]
+extern crate log;
 
 use nftnl_sys::c_void;
 

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -12,6 +12,7 @@ error_chain! {
     }
 }
 
+pub mod expr;
 
 mod table;
 pub use table::Table;
@@ -19,6 +20,8 @@ pub use table::Table;
 mod chain;
 pub use chain::{Chain, Hook, Priority};
 
+mod rule;
+pub use rule::Rule;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum MsgType {

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -1,0 +1,84 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use chain::Chain;
+use expr::Expression;
+use {ErrorKind, MsgType, Result};
+
+pub struct Rule<'a> {
+    rule: *mut sys::nftnl_rule,
+    chain: &'a Chain<'a>,
+}
+
+impl<'a> Rule<'a> {
+    pub fn new(chain: &'a Chain) -> Result<Rule<'a>> {
+        unsafe {
+            let rule = sys::nftnl_rule_alloc();
+            if rule.is_null() {
+                bail!(ErrorKind::AllocationError);
+            }
+
+            sys::nftnl_rule_set_str(
+                rule,
+                sys::NFTNL_RULE_TABLE as u16,
+                chain.get_table().get_name().as_ptr(),
+            );
+            sys::nftnl_rule_set_str(
+                rule,
+                sys::NFTNL_RULE_CHAIN as u16,
+                chain.get_name().as_ptr(),
+            );
+            sys::nftnl_rule_set_u32(
+                rule,
+                sys::NFTNL_RULE_FAMILY as u16,
+                chain.get_table().get_family() as u32,
+            );
+
+            Ok(Rule { rule, chain })
+        }
+    }
+
+    pub fn set_position(&mut self, position: u64) {
+        unsafe {
+            sys::nftnl_rule_set_u64(self.rule, sys::NFTNL_RULE_POSITION as u16, position);
+        }
+    }
+
+    pub fn set_handle(&mut self, handle: u64) {
+        unsafe {
+            sys::nftnl_rule_set_u64(self.rule, sys::NFTNL_RULE_HANDLE as u16, handle);
+        }
+    }
+
+    pub fn add_expr<E: Expression>(&mut self, expr: E) -> Result<()> {
+        unsafe { sys::nftnl_rule_add_expr(self.rule, expr.to_expr()?) }
+        Ok(())
+    }
+
+    pub fn get_chain(&self) -> &Chain {
+        self.chain
+    }
+}
+
+unsafe impl<'a> ::NlMsg for Rule<'a> {
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
+        let type_ = match msg_type {
+            MsgType::Add => libc::NFT_MSG_NEWRULE,
+            MsgType::Del => libc::NFT_MSG_DELRULE,
+        };
+        let header = sys::nftnl_nlmsg_build_hdr(
+            buf as *mut i8,
+            type_ as u16,
+            self.chain.get_table().get_family() as u16,
+            (libc::NLM_F_APPEND | libc::NLM_F_CREATE | libc::NLM_F_EXCL) as u16,
+            seq,
+        );
+        sys::nftnl_rule_nlmsg_build_payload(header, self.rule);
+    }
+}
+
+impl<'a> Drop for Rule<'a> {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_rule_free(self.rule) };
+    }
+}


### PR DESCRIPTION
I previously added the `Table` type, which is the top level "container". Under that we already have `Chain` in place. Now comes the things you put in the `Chain`s, `Rule`s. And each rule is built up of `Expression`s

The way nftables/netfilter works is that it's more or less a primitive programming language for loading network packet information into registers and then doing operations on those registers and finally end up in a verdict for the packet.

A rule looking like `tcp dport 987 accept` (any packet having tcp destination port == 987 is accepted) when entered into the `nft` tool is under the hood constructed like this in `libnftnl`:
```rust
// Create a new `Rule` in the chain
let mut rule = Rule::new(&my_chain)?;

// Load the "protocol" field of the IPv4 header into the netfilter register
// (hardcoded to REG_1 for now)
rule.add_expr(nft_expr!(payload ip protocol))?;
// Compare the value in the register (REG_1) with `libc::IPPROTO_TCP as u8`.
// A `Cmp` expression that does not match aborts execution of further expressions
// on this rule and netfilter continues with the next rule.
// If the comparison matches the next expression is executed.
rule.add_expr(nft_expr!(cmp == libc::IPPROTO_TCP as u8))?;

// Load the destination port field from the tcp header into REG_1
rule.add_expr(nft_expr!(payload tcp dport))?;
// Compare the value in REG_1 to `987` in big endian (network endian)
rule.add_expr(nft_expr!(cmp == 987.to_be()))?;

// Add a verdict accept expression. If the execution get this far the packet is accepted.
// The "verdict" expression type is not added in this PR. It comes later.
rule.add_expr(nft_expr!(verdict accept)).unwrap();
```
My highly work in progress attempt at integrating this into `mullvad-daemon` can be viewed on the `linux-firewall-integration` branch. For example, here is how I create the "allow loopback" rules:
https://github.com/mullvad/mullvadvpn-app/blob/linux-firewall-integration/talpid-core/src/firewall/linux/mod.rs#L174

Expressions can be created completely without using the macros. But it becomes very verbose. Which is why I added macros that sort of mimics the semantics one would give to create rules in the `nft` CLI tool. So you understand the difference here is an example:
```rust
nft_expr!(payload tcp dport)

// Is expanded to
nftnl::expr::Payload::Transport(nftnl::expr::TransportHeaderField::Tcp(nftnl::expr::TcpHeaderField::Dport))

// Which, with some sane `use` statements would become:
Payload::Transport(TransportHeaderField::Tcp(TcpHeaderField::Dport))
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/4)
<!-- Reviewable:end -->
