### PR TITLE
Add Batch and FinalizedBatch

### DIFF
--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,0 +1,148 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use std::ptr;
+use {ErrorKind, MsgType, NlMsg, Result};
+
+/// Check if the kernel supports batched netlink messages to netfilter.
+pub fn batch_is_supported() -> Result<bool> {
+    match unsafe { sys::nftnl_batch_is_supported() } {
+        1 => Ok(true),
+        0 => Ok(false),
+        _ => bail!(ErrorKind::NetlinkError),
+    }
+}
+
+pub struct Batch {
+    batch: *mut sys::nftnl_batch,
+    seq: u32,
+}
+
+impl Batch {
+    /// Creates a new nftnl batch with the [default page size]
+    ///
+    /// [default page size]: fn.default_batch_page_size.html
+    pub fn new() -> Result<Self> {
+        Self::with_page_size(default_batch_page_size())
+    }
+
+    pub fn with_page_size(batch_page_size: u32) -> Result<Self> {
+        let batch = unsafe { sys::nftnl_batch_alloc(batch_page_size, ::nft_nlmsg_maxsize()) };
+        if batch.is_null() {
+            bail!(ErrorKind::AllocationError);
+        }
+        let mut this = Batch { batch, seq: 1 };
+        this.write_begin_msg()?;
+        Ok(this)
+    }
+
+    pub fn add<T: NlMsg>(&mut self, msg: &T, msg_type: MsgType) -> Result<()> {
+        trace!("Writing NlMsg with seq {} to batch", self.seq);
+        unsafe { msg.write(self.current(), self.seq, msg_type) };
+        self.next()
+    }
+
+    pub fn add_iter<T, I>(&mut self, msg_iter: I, msg_type: MsgType) -> Result<()>
+    where
+        T: NlMsg,
+        I: Iterator<Item = T>,
+    {
+        for msg in msg_iter {
+            self.add(&msg, msg_type)?;
+        }
+        Ok(())
+    }
+
+    pub fn finalize(mut self) -> Result<FinalizedBatch> {
+        self.write_end_msg()?;
+        Ok(FinalizedBatch { batch: self })
+    }
+
+    fn current(&self) -> *mut c_void {
+        unsafe { sys::nftnl_batch_buffer(self.batch) }
+    }
+
+    fn next(&mut self) -> Result<()> {
+        if unsafe { sys::nftnl_batch_update(self.batch) } < 0 {
+            bail!(ErrorKind::AllocationError);
+        }
+        self.seq += 1;
+        Ok(())
+    }
+
+    fn write_begin_msg(&mut self) -> Result<()> {
+        unsafe { sys::nftnl_batch_begin(self.current() as *mut i8, self.seq) };
+        self.next()
+    }
+
+    fn write_end_msg(&mut self) -> Result<()> {
+        unsafe { sys::nftnl_batch_end(self.current() as *mut i8, self.seq) };
+        self.next()
+    }
+
+    pub fn as_raw_batch(&self) -> *mut sys::nftnl_batch {
+        self.batch
+    }
+}
+
+impl Drop for Batch {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_batch_free(self.batch) };
+    }
+}
+
+pub struct FinalizedBatch {
+    batch: Batch,
+}
+
+impl FinalizedBatch {
+    pub fn iter<'a>(&'a self) -> Iter<'a> {
+        let num_pages = unsafe { sys::nftnl_batch_iovec_len(self.batch.as_raw_batch()) as usize };
+        let mut iovecs = vec![
+            libc::iovec {
+                iov_base: ptr::null_mut(),
+                iov_len: 0,
+            };
+            num_pages
+        ];
+        let iovecs_ptr = iovecs.as_mut_ptr() as *mut sys::iovec;
+        unsafe {
+            sys::nftnl_batch_iovec(self.batch.as_raw_batch(), iovecs_ptr, num_pages as u32);
+        }
+        Iter {
+            iovecs: iovecs.into_iter(),
+            _marker: ::std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a FinalizedBatch {
+    type Item = &'a [u8];
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+pub struct Iter<'a> {
+    iovecs: ::std::vec::IntoIter<libc::iovec>,
+    _marker: ::std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<&'a [u8]> {
+        self.iovecs.next().map(|iovec| unsafe {
+            ::std::slice::from_raw_parts(iovec.iov_base as *const u8, iovec.iov_len)
+        })
+    }
+}
+
+/// selected batch page is 256 Kbytes long to load ruleset of
+/// half a million rules without hitting -EMSGSIZE due to large
+/// iovec.
+pub fn default_batch_page_size() -> u32 {
+    unsafe { libc::sysconf(libc::_SC_PAGESIZE) as u32 * 32 }
+}

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -28,9 +28,7 @@ impl Batch {
 
     pub fn with_page_size(batch_page_size: u32) -> Result<Self> {
         let batch = unsafe { sys::nftnl_batch_alloc(batch_page_size, ::nft_nlmsg_maxsize()) };
-        if batch.is_null() {
-            bail!(ErrorKind::AllocationError);
-        }
+        ensure!(!batch.is_null(), ErrorKind::AllocationError);
         let mut this = Batch { batch, seq: 1 };
         this.write_begin_msg()?;
         Ok(this)

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -39,9 +39,7 @@ impl<'a> Chain<'a> {
     pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Result<Chain<'a>> {
         unsafe {
             let chain = sys::nftnl_chain_alloc();
-            if chain.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!chain.is_null(), ErrorKind::AllocationError);
 
             sys::nftnl_chain_set_str(
                 chain,

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -59,9 +59,7 @@ impl<T: ToSlice> Expression for Cmp<T> {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
             let expr = sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const c_char);
-            if expr.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!expr.is_null(), ErrorKind::AllocationError);
 
             let data = self.data.to_slice();
             trace!("Creating a cmp expr comparing with data {:?}", data);

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -10,9 +10,7 @@ impl Expression for Counter {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
             let expr = sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char);
-            if expr.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!expr.is_null(), ErrorKind::AllocationError);
             Ok(expr)
         }
     }

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -41,9 +41,8 @@ impl Expression for Meta {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
             let expr = sys::nftnl_expr_alloc(b"meta\0" as *const _ as *const c_char);
-            if expr.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+
             sys::nftnl_expr_set_u32(
                 expr,
                 sys::NFTNL_EXPR_META_DREG as u16,

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -52,9 +52,7 @@ impl Expression for Payload {
     fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
         unsafe {
             let expr = sys::nftnl_expr_alloc(b"payload\0" as *const _ as *const c_char);
-            if expr.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!expr.is_null(), ErrorKind::AllocationError);
 
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_PAYLOAD_BASE as u16, self.base());
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_PAYLOAD_OFFSET as u16, self.offset());

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -11,8 +11,13 @@ use nftnl_sys::c_void;
 error_chain! {
     errors {
         AllocationError { description("Unable to allocate memory") }
+        BatchIsFull { description("Not enough room in the batch") }
+        NetlinkError { description("Error while communicating with netlink") }
     }
 }
+
+mod batch;
+pub use batch::{batch_is_supported, default_batch_page_size, Batch, FinalizedBatch};
 
 pub mod expr;
 

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -14,9 +14,7 @@ impl<'a> Rule<'a> {
     pub fn new(chain: &'a Chain) -> Result<Rule<'a>> {
         unsafe {
             let rule = sys::nftnl_rule_alloc();
-            if rule.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!rule.is_null(), ErrorKind::AllocationError);
 
             sys::nftnl_rule_set_str(
                 rule,

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -20,9 +20,7 @@ impl Table {
     pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Result<Table> {
         unsafe {
             let table = sys::nftnl_table_alloc();
-            if table.is_null() {
-                bail!(ErrorKind::AllocationError);
-            }
+            ensure!(!table.is_null(), ErrorKind::AllocationError);
 
             sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
             sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FAMILY as u16, family as u32);


### PR DESCRIPTION
Add `Batch` support. A `Batch` is a series of netlink messages that are processed atomically. Thus allowing us to replace an entire ruleset with a new one without any inconsistent state in between.

Batches are natively supported by `libnftnl`, so this is basically just a safe Rust wrapper on top of it.

We force the addition of the begin batch message upon `Batch` creation and we force the addition of the end batch message before converting to a `FinalizedBatch`. Since `FinalizedBatch` is the only type allowing you to get the actual netlink messages out it becomes possible to send a batch without proper begin and end messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/5)
<!-- Reviewable:end -->
