### PR TITLE
Add set and lookup

### DIFF
--- a/nftnl/src/expr/lookup.rs
+++ b/nftnl/src/expr/lookup.rs
@@ -1,0 +1,58 @@
+use libc;
+use nftnl_sys::{self as sys, c_char};
+
+use std::ffi::CString;
+
+use super::Expression;
+use set::Set;
+use {ErrorKind, Result};
+
+pub struct Lookup {
+    set_name: CString,
+    set_id: u32,
+}
+
+impl Lookup {
+    pub fn new<K>(set: &Set<K>) -> Self {
+        Lookup {
+            set_name: set.get_name().to_owned(),
+            set_id: set.get_id(),
+        }
+    }
+}
+
+impl Expression for Lookup {
+    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+        unsafe {
+            let expr = sys::nftnl_expr_alloc(b"lookup\0" as *const _ as *const c_char);
+            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_LOOKUP_SREG as u16,
+                libc::NFT_REG_1 as u32,
+            );
+            sys::nftnl_expr_set_str(
+                expr,
+                sys::NFTNL_EXPR_LOOKUP_SET as u16,
+                self.set_name.as_ptr() as *const _ as *const c_char,
+            );
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_LOOKUP_SET_ID as u16, self.set_id);
+
+            // This code is left here since it's quite likely we need it again when we get further
+            // if self.reverse {
+            //     sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_LOOKUP_FLAGS as u16,
+            //         libc::NFT_LOOKUP_F_INV as u32);
+            // }
+
+            Ok(expr)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_lookup {
+    ($set:expr) => {
+        $crate::expr::Lookup::new($set)
+    };
+}

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -18,6 +18,9 @@ pub use self::counter::*;
 mod immediate;
 pub use self::immediate::*;
 
+mod lookup;
+pub use self::lookup::*;
+
 mod meta;
 pub use self::meta::*;
 
@@ -40,6 +43,9 @@ macro_rules! nft_expr {
     };
     (verdict $verdict:ident $chain:expr) => {
         nft_expr_verdict!($verdict $chain)
+    };
+    (lookup $set:expr) => {
+        nft_expr_lookup!($set)
     };
     (meta $expr:ident) => {
         nft_expr_meta!($expr)

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -30,6 +30,8 @@ pub use chain::{Chain, Hook, Priority};
 mod rule;
 pub use rule::Rule;
 
+pub mod set;
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum MsgType {
     Add,

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -1,0 +1,231 @@
+use libc;
+use nftnl_sys::{self as sys, c_void};
+
+use std::cell::Cell;
+use std::ffi::CStr;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::rc::Rc;
+use table::Table;
+use {ErrorKind, MsgType, ProtoFamily, Result};
+
+
+#[macro_export]
+macro_rules! nft_set {
+    ($name:expr, $id:expr, $table:expr, $family:expr) => {
+        $crate::set::Set::new($name, $id, $table, $family)
+    };
+    ($name:expr, $id:expr, $table:expr, $family:expr; [ ]) => {
+        nft_set!($name, $id, $table, $family)
+    };
+    ($name:expr, $id:expr, $table:expr, $family:expr; [ $($value:expr,)* ]) => {{
+        let mut set = nft_set!($name, $id, $table, $family).expect("Set allocation failed");
+        $(
+            set.add($value).expect(stringify!(Unable to add $value to set $name));
+        )*
+        set
+    }};
+}
+
+pub struct Set<'a, K> {
+    set: *mut sys::nftnl_set,
+    table: &'a Table,
+    family: ProtoFamily,
+    _marker: ::std::marker::PhantomData<K>,
+}
+
+impl<'a, K> Set<'a, K> {
+    pub fn new(name: &CStr, id: u32, table: &'a Table, family: ProtoFamily) -> Result<Self>
+    where
+        K: SetKey,
+    {
+        unsafe {
+            let set = sys::nftnl_set_alloc();
+            ensure!(!set.is_null(), ErrorKind::AllocationError);
+
+            sys::nftnl_set_set_u32(set, sys::NFTNL_SET_FAMILY as u16, family as u32);
+            sys::nftnl_set_set_str(set, sys::NFTNL_SET_TABLE as u16, table.get_name().as_ptr());
+            sys::nftnl_set_set_str(set, sys::NFTNL_SET_NAME as u16, name.as_ptr());
+            sys::nftnl_set_set_u32(set, sys::NFTNL_SET_ID as u16, id);
+
+            sys::nftnl_set_set_u32(
+                set,
+                sys::NFTNL_SET_FLAGS as u16,
+                (libc::NFT_SET_ANONYMOUS | libc::NFT_SET_CONSTANT) as u32,
+            );
+            sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_TYPE as u16, K::TYPE);
+            sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_LEN as u16, K::LEN);
+
+            Ok(Set {
+                set,
+                table,
+                family,
+                _marker: ::std::marker::PhantomData,
+            })
+        }
+    }
+
+    pub fn add(&mut self, key: &K) -> Result<()>
+    where
+        K: SetKey,
+    {
+        unsafe {
+            let elem = sys::nftnl_set_elem_alloc();
+            ensure!(!elem.is_null(), ErrorKind::AllocationError);
+
+            let data = key.data();
+            let data_len = data.len() as u32;
+            trace!("Adding key {:?} with len {}", data, data_len);
+            sys::nftnl_set_elem_set(
+                elem,
+                sys::NFTNL_SET_ELEM_KEY as u16,
+                data.as_ref() as *const _ as *const c_void,
+                data_len,
+            );
+            sys::nftnl_set_elem_add(self.set, elem);
+        }
+        Ok(())
+    }
+
+    pub fn elems_iter(&'a self) -> Result<SetElemsIter<'a, K>> {
+        SetElemsIter::new(self)
+    }
+
+    pub fn as_ptr(&self) -> *mut sys::nftnl_set {
+        self.set
+    }
+
+    pub fn get_family(&self) -> ProtoFamily {
+        self.family
+    }
+
+    pub fn get_name(&self) -> &CStr {
+        unsafe {
+            let ptr = sys::nftnl_set_get_str(self.set, sys::NFTNL_SET_NAME as u16);
+            CStr::from_ptr(ptr)
+        }
+    }
+
+    pub fn get_id(&self) -> u32 {
+        unsafe { sys::nftnl_set_get_u32(self.set, sys::NFTNL_SET_ID as u16) }
+    }
+}
+
+unsafe impl<'a, K> ::NlMsg for Set<'a, K> {
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
+        let type_ = match msg_type {
+            MsgType::Add => libc::NFT_MSG_NEWSET,
+            MsgType::Del => libc::NFT_MSG_DELSET,
+        };
+        let header = sys::nftnl_nlmsg_build_hdr(
+            buf as *mut i8,
+            type_ as u16,
+            self.table.get_family() as u16,
+            (libc::NLM_F_APPEND | libc::NLM_F_CREATE | libc::NLM_F_ACK) as u16,
+            seq,
+        );
+        sys::nftnl_set_nlmsg_build_payload(header, self.set);
+    }
+}
+
+impl<'a, K> Drop for Set<'a, K> {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_set_free(self.set) };
+    }
+}
+
+pub struct SetElemsIter<'a, K: 'a> {
+    set: &'a Set<'a, K>,
+    iter: *mut sys::nftnl_set_elems_iter,
+    ret: Rc<Cell<i32>>,
+}
+
+impl<'a, K> SetElemsIter<'a, K> {
+    fn new(set: &'a Set<'a, K>) -> Result<Self> {
+        let iter = unsafe { sys::nftnl_set_elems_iter_create(set.as_ptr()) };
+        ensure!(!iter.is_null(), ErrorKind::AllocationError);
+
+        Ok(SetElemsIter {
+            set,
+            iter,
+            ret: Rc::new(Cell::new(1)),
+        })
+    }
+}
+
+impl<'a, K: 'a> Iterator for SetElemsIter<'a, K> {
+    type Item = SetElemsMsg<'a, K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ret.get() <= 0 || unsafe { sys::nftnl_set_elems_iter_cur(self.iter).is_null() } {
+            trace!("SetElemsIter iterator ending");
+            None
+        } else {
+            trace!("SetElemsIter returning new SetElemsMsg");
+            Some(SetElemsMsg {
+                set: self.set,
+                iter: self.iter,
+                ret: self.ret.clone(),
+            })
+        }
+    }
+}
+
+impl<'a, K> Drop for SetElemsIter<'a, K> {
+    fn drop(&mut self) {
+        unsafe { sys::nftnl_set_elems_iter_destroy(self.iter) };
+    }
+}
+
+pub struct SetElemsMsg<'a, K: 'a> {
+    set: &'a Set<'a, K>,
+    iter: *mut sys::nftnl_set_elems_iter,
+    ret: Rc<Cell<i32>>,
+}
+
+unsafe impl<'a, K> ::NlMsg for SetElemsMsg<'a, K> {
+    unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
+        trace!("Writing SetElemsMsg to NlMsg");
+        let (type_, flags) = match msg_type {
+            MsgType::Add => (
+                libc::NFT_MSG_NEWSETELEM,
+                libc::NLM_F_CREATE | libc::NLM_F_EXCL | libc::NLM_F_ACK,
+            ),
+            MsgType::Del => (libc::NFT_MSG_DELSETELEM, libc::NLM_F_ACK),
+        };
+        let header = sys::nftnl_nlmsg_build_hdr(
+            buf as *mut i8,
+            type_ as u16,
+            self.set.get_family() as u16,
+            flags as u16,
+            seq,
+        );
+        self.ret.set(sys::nftnl_set_elems_nlmsg_build_payload_iter(
+            header, self.iter,
+        ));
+    }
+}
+
+pub trait SetKey {
+    const TYPE: u32;
+    const LEN: u32;
+
+    fn data(&self) -> Box<[u8]>;
+}
+
+impl SetKey for Ipv4Addr {
+    const TYPE: u32 = 7;
+    const LEN: u32 = 4;
+
+    fn data(&self) -> Box<[u8]> {
+        self.octets().to_vec().into_boxed_slice()
+    }
+}
+
+impl SetKey for Ipv6Addr {
+    const TYPE: u32 = 8;
+    const LEN: u32 = 16;
+
+    fn data(&self) -> Box<[u8]> {
+        self.octets().to_vec().into_boxed_slice()
+    }
+}


### PR DESCRIPTION
Adding the `Set` type that is a collection of values one can use in rules. Combined with the `Lookup` expression one can build rules kind of like `ip saddr in { 10.0.0.3, 10.0.0.9 } drop` to drop all packets from those two addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/6)
<!-- Reviewable:end -->
