### PR TITLE
Add build.rs check for LIB{MNL,NFTNL}_LIB_DIR and use to link

### DIFF
--- a/nftnl-sys/build.rs
+++ b/nftnl-sys/build.rs
@@ -1,5 +1,8 @@
 extern crate pkg_config;
 
+use std::env;
+use std::path::PathBuf;
+
 #[cfg(feature = "nftnl-1-1-0")]
 const MIN_VERSION: &str = "1.1.0";
 
@@ -16,9 +19,38 @@ const MIN_VERSION: &str = "1.0.7";
 const MIN_VERSION: &str = "1.0.6";
 
 fn main() {
-    println!("Minimum libnftnl version: {}", MIN_VERSION);
-    pkg_config::Config::new()
-        .atleast_version(MIN_VERSION)
-        .probe("libnftnl")
-        .unwrap();
+    if let Ok(lib_dir) = env::var("LIBNFTNL_LIB_DIR").map(PathBuf::from) {
+        if !lib_dir.is_dir() {
+            panic!(
+                "libnftnl library directory does not exist: {}",
+                lib_dir.display()
+            );
+        }
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:rustc-link-lib=nftnl");
+    } else {
+        // Trying with pkg-config instead
+        println!("Minimum libnftnl version: {}", MIN_VERSION);
+        pkg_config::Config::new()
+            .atleast_version(MIN_VERSION)
+            .probe("libnftnl")
+            .unwrap();
+    }
+
+    if let Ok(lib_dir) = env::var("LIBMNL_LIB_DIR").map(PathBuf::from) {
+        if !lib_dir.is_dir() {
+            panic!(
+                "libmnl library directory does not exist: {}",
+                lib_dir.display()
+            );
+        }
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:rustc-link-lib=mnl");
+    } else {
+        // Trying with pkg-config instead
+        pkg_config::Config::new()
+            .atleast_version("1.0.0")
+            .probe("libmnl")
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Equivalent to https://github.com/mullvad/mnl-rs/pull/5 but for this library.

Here we have to emit linking information for both `libnftnl` and `libmnl` since `libnftnl` depends on `libmnl`.

For some reason I don't understand it seems to be important in which order they are emitted. If I emit the `libmnl` linking stuff first it won't compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/11)
<!-- Reviewable:end -->
