### PR TITLE
Upgrade error-chain to 0.12 and expose it publicly

### DIFF
--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -16,7 +16,7 @@ nftnl-1-1-0 = ["nftnl-sys/nftnl-1-1-0"]
 
 [dependencies]
 bitflags = "1.0"
-error-chain = "0.11"
+error-chain = "0.12"
 libc = "0.2.40"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -10,6 +10,7 @@ extern crate log;
 
 use nftnl_sys::c_void;
 
+pub use error_chain::ChainedError;
 error_chain! {
     errors {
         AllocationError { description("Unable to allocate memory") }


### PR DESCRIPTION
To also bring the Linux firewall integration into sync with the rest I want to upgrade error-chain. And same as the other crates, as to not repeat old mistakes, expose the `ChainedError` trait publicly so users of this lib can use `display_chain` without having to depend on the same version of `error-chain` themselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/13)
<!-- Reviewable:end -->
