### PR TITLE
Fix warnings emitted by clippy

### DIFF
--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -94,7 +94,7 @@ pub struct FinalizedBatch {
 }
 
 impl FinalizedBatch {
-    pub fn iter<'a>(&'a self) -> Iter<'a> {
+    pub fn iter(&self) -> Iter {
         let num_pages = unsafe { sys::nftnl_batch_iovec_len(self.batch.as_raw_batch()) as usize };
         let mut iovecs = vec![
             libc::iovec {

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -27,9 +27,9 @@ pub enum CmpOp {
 }
 
 impl CmpOp {
-    pub fn to_raw(&self) -> u32 {
+    pub fn to_raw(self) -> u32 {
         use self::CmpOp::*;
-        match *self {
+        match self {
             Eq => libc::NFT_CMP_EQ as u32,
             Neq => libc::NFT_CMP_NEQ as u32,
             Lt => libc::NFT_CMP_LT as u32,

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -19,8 +19,8 @@ pub enum Payload {
 
 
 impl Payload {
-    fn base(&self) -> u32 {
-        match *self {
+    fn base(self) -> u32 {
+        match self {
             // Payload::LinkLayer(_) => libc::NFT_PAYLOAD_LL_HEADER as u32,
             Payload::Network(_) => libc::NFT_PAYLOAD_NETWORK_HEADER as u32,
             Payload::Transport(_) => libc::NFT_PAYLOAD_TRANSPORT_HEADER as u32,

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -75,5 +75,5 @@ pub unsafe trait NlMsg {
 /// length (nla_len) is 16 bits, the largest message is a bit larger than
 /// 64 KBytes.
 pub fn nft_nlmsg_maxsize() -> u32 {
-    ::std::u16::MAX as u32 + unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32
+    u32::from(::std::u16::MAX) + unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32
 }

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -48,7 +48,7 @@ impl<'a> Rule<'a> {
         }
     }
 
-    pub fn add_expr<E: Expression>(&mut self, expr: E) -> Result<()> {
+    pub fn add_expr(&mut self, expr: &impl Expression) -> Result<()> {
         unsafe { sys::nftnl_rule_add_expr(self.rule, expr.to_expr()?) }
         Ok(())
     }


### PR DESCRIPTION
Now when clippy is available via rustup lazy me finally got around to run it on a few more libraries. Here I'm cleaning up what it complains about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/14)
<!-- Reviewable:end -->
