### PR TITLE
Remove error chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgrade crates to Rust 2018 edition.
-- Remove the `error-chain` dependency and introduce new error types.
+- Remove the `error-chain` dependency. Now panics on allocation error.
 
 
 ## [0.1.0] - 2018-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `add-get-tables-request` that can create requests to enumerate tables.
 
 ### Changed
-- Upgraded crates to Rust 2018 edition.
+- Upgrade crates to Rust 2018 edition.
+- Remove the `error-chain` dependency and introduce new error types.
 
 
 ## [0.1.0] - 2018-09-10

--- a/nftnl-sys/build.rs
+++ b/nftnl-sys/build.rs
@@ -1,7 +1,6 @@
 extern crate pkg_config;
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 #[cfg(feature = "nftnl-1-1-1")]
 const MIN_VERSION: &str = "1.1.1";

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -19,7 +19,7 @@ nftnl-1-1-1 = ["nftnl-sys/nftnl-1-1-1"]
 
 [dependencies]
 bitflags = "1.0"
-error-chain = "0.12"
+err-derive = "0.1.5"
 libc = "0.2.40"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -25,5 +25,5 @@ log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.1" }
 
 [dev-dependencies]
-ipnetwork = "0.13"
+ipnetwork = "0.14"
 mnl = "0.1"

--- a/nftnl/examples/add-rules.rs
+++ b/nftnl/examples/add-rules.rs
@@ -37,7 +37,7 @@
 //! ```
 
 use ipnetwork::{IpNetwork, Ipv4Network};
-use nftnl::{nft_expr, Batch, Chain, ChainedError, FinalizedBatch, ProtoFamily, Rule, Table};
+use nftnl::{nft_expr, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
 use std::{
     ffi::{self, CString},
     io,
@@ -206,7 +206,7 @@ struct Error(String);
 
 impl From<nftnl::Error> for Error {
     fn from(error: nftnl::Error) -> Self {
-        Error(error.display_chain().to_string())
+        Error(error.to_string())
     }
 }
 

--- a/nftnl/examples/add-rules.rs
+++ b/nftnl/examples/add-rules.rs
@@ -53,17 +53,17 @@ fn main() -> Result<(), Error> {
     // Create a batch. This is used to store all the netlink messages we will later send.
     // Creating a new batch also automatically writes the initial batch begin message needed
     // to tell netlink this is a single transaction that might arrive over multiple netlink packets.
-    let mut batch = Batch::new()?;
+    let mut batch = Batch::new();
 
     // Create a netfilter table operating on both IPv4 and IPv6 (ProtoFamily::Inet)
-    let table = Table::new(&CString::new(TABLE_NAME).unwrap(), ProtoFamily::Inet)?;
+    let table = Table::new(&CString::new(TABLE_NAME).unwrap(), ProtoFamily::Inet);
     // Add the table to the batch with the `MsgType::Add` type, thus instructing netfilter to add
     // this table under its `ProtoFamily::Inet` ruleset.
-    batch.add(&table, nftnl::MsgType::Add)?;
+    batch.add(&table, nftnl::MsgType::Add);
 
     // Create input and output chains under the table we created above.
-    let mut out_chain = Chain::new(&CString::new(OUT_CHAIN_NAME).unwrap(), &table)?;
-    let mut in_chain = Chain::new(&CString::new(IN_CHAIN_NAME).unwrap(), &table)?;
+    let mut out_chain = Chain::new(&CString::new(OUT_CHAIN_NAME).unwrap(), &table);
+    let mut in_chain = Chain::new(&CString::new(IN_CHAIN_NAME).unwrap(), &table);
 
     // Hook the chains to the input and output event hooks, with highest priority (priority zero).
     // See the `Chain::set_hook` documentation for details.
@@ -77,14 +77,14 @@ fn main() -> Result<(), Error> {
 
     // Add the two chains to the batch with the `MsgType` to tell netfilter to create the chains
     // under the table.
-    batch.add(&out_chain, nftnl::MsgType::Add)?;
-    batch.add(&in_chain, nftnl::MsgType::Add)?;
+    batch.add(&out_chain, nftnl::MsgType::Add);
+    batch.add(&in_chain, nftnl::MsgType::Add);
 
 
     // === ADD RULE ALLOWING ALL TRAFFIC TO THE LOOPBACK DEVICE ===
 
     // Create a new rule object under the input chain.
-    let mut allow_loopback_in_rule = Rule::new(&in_chain)?;
+    let mut allow_loopback_in_rule = Rule::new(&in_chain);
     // Lookup the interface index of the loopback interface.
     let lo_iface_index = iface_index("lo")?;
 
@@ -93,42 +93,42 @@ fn main() -> Result<(), Error> {
     // When an incoming network packet is processed by this rule it will first be processed by this
     // expression, which will load the interface index of the interface the packet came from into
     // a special "register" in netfilter.
-    allow_loopback_in_rule.add_expr(&nft_expr!(meta iif))?;
+    allow_loopback_in_rule.add_expr(&nft_expr!(meta iif));
     // Next expression in the rule is to compare the value loaded into the register with our desired
     // interface index, and succeed only if it's equal. For any packet processed where the equality
     // does not hold the packet is said to not match this rule, and the packet moves on to be
     // processed by the next rule in the chain instead.
-    allow_loopback_in_rule.add_expr(&nft_expr!(cmp == lo_iface_index))?;
+    allow_loopback_in_rule.add_expr(&nft_expr!(cmp == lo_iface_index));
 
     // Add a verdict expression to the rule. Any packet getting this far in the expression
     // processing without failing any expression will be given the verdict added here.
-    allow_loopback_in_rule.add_expr(&nft_expr!(verdict accept))?;
+    allow_loopback_in_rule.add_expr(&nft_expr!(verdict accept));
 
     // Add the rule to the batch.
-    batch.add(&allow_loopback_in_rule, nftnl::MsgType::Add)?;
+    batch.add(&allow_loopback_in_rule, nftnl::MsgType::Add);
 
 
     // === ADD A RULE ALLOWING (AND COUNTING) ALL PACKETS TO THE 10.1.0.0/24 NETWORK ===
 
-    let mut block_out_to_private_net_rule = Rule::new(&out_chain)?;
+    let mut block_out_to_private_net_rule = Rule::new(&out_chain);
     let private_net_ip = Ipv4Addr::new(10, 1, 0, 0);
     let private_net_prefix = 24;
     let private_net = IpNetwork::V4(Ipv4Network::new(private_net_ip, private_net_prefix)?);
 
     // Load the `nfproto` metadata into the netfilter register. This metadata denotes which layer3
     // protocol the packet being processed is using.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(meta nfproto))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(meta nfproto));
     // Check if the currently processed packet is an IPv4 packet. This must be done before payload
     // data assuming the packet uses IPv4 can be loaded in the next expression.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(cmp == libc::NFPROTO_IPV4 as u8))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(cmp == libc::NFPROTO_IPV4 as u8));
 
     // Load the IPv4 destination address into the netfilter register.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(payload ipv4 daddr))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(payload ipv4 daddr));
     // Mask out the part of the destination address that is not part of the network bits. The result
     // of this bitwise masking is stored back into the same netfilter register.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(bitwise mask private_net.mask(), xor 0))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(bitwise mask private_net.mask(), xor 0));
     // Compare the result of the masking with the IP of the network we are interested in.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(cmp == private_net.ip()))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(cmp == private_net.ip()));
 
     // Add a packet counter to the rule. Shows how many packets have been evaluated against this
     // expression. Since expressions are evaluated from first to last, putting this counter before
@@ -136,14 +136,14 @@ fn main() -> Result<(), Error> {
     // those expressions. Because the counter would then be evaluated before it fails a check.
     // Similarly, if the counter was added after the verdict it would always remain at zero. Since
     // when the packet hits the verdict expression any further processing of expressions stop.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(counter))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(counter));
 
     // Accept all the packets matching the rule so far.
-    block_out_to_private_net_rule.add_expr(&nft_expr!(verdict accept))?;
+    block_out_to_private_net_rule.add_expr(&nft_expr!(verdict accept));
 
     // Add the rule to the batch. Without this nothing would be sent over netlink and netfilter,
     // and all the work on `block_out_to_private_net_rule` so far would go to waste.
-    batch.add(&block_out_to_private_net_rule, nftnl::MsgType::Add)?;
+    batch.add(&block_out_to_private_net_rule, nftnl::MsgType::Add);
 
 
     // === FINALIZE THE TRANSACTION AND SEND THE DATA TO NETFILTER ===
@@ -152,7 +152,7 @@ fn main() -> Result<(), Error> {
     // netfilter the we reached the end of the transaction message. It's also converted to a type
     // that implements `IntoIterator<Item = &'a [u8]>`, thus allowing us to get the raw netlink data
     // out so it can be sent over a netlink socket to netfilter.
-    let finalized_batch = batch.finalize()?;
+    let finalized_batch = batch.finalize();
 
     // Send the entire batch and process any returned messages.
     send_and_process(&finalized_batch)?;
@@ -203,12 +203,6 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
 
 #[derive(Debug)]
 struct Error(String);
-
-impl From<nftnl::AllocationError> for Error {
-    fn from(error: nftnl::AllocationError) -> Self {
-        Error(error.to_string())
-    }
-}
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {

--- a/nftnl/examples/add-rules.rs
+++ b/nftnl/examples/add-rules.rs
@@ -204,8 +204,8 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
 #[derive(Debug)]
 struct Error(String);
 
-impl From<nftnl::Error> for Error {
-    fn from(error: nftnl::Error) -> Self {
+impl From<nftnl::AllocationError> for Error {
+    fn from(error: nftnl::AllocationError) -> Self {
         Error(error.to_string())
     }
 }

--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -22,7 +22,7 @@
 //! # nft delete table inet example-filter-ethernet
 //! ```
 
-use nftnl::{nft_expr, Batch, Chain, ChainedError, FinalizedBatch, ProtoFamily, Rule, Table};
+use nftnl::{nft_expr, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
 use std::{ffi::CString, io};
 
 const TABLE_NAME: &str = "example-filter-ethernet";
@@ -126,7 +126,7 @@ struct Error(String);
 
 impl From<nftnl::Error> for Error {
     fn from(error: nftnl::Error) -> Self {
-        Error(error.display_chain().to_string())
+        Error(error.to_string())
     }
 }
 

--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -125,8 +125,8 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
 #[derive(Debug)]
 struct Error(String);
 
-impl From<nftnl::Error> for Error {
-    fn from(error: nftnl::Error) -> Self {
+impl From<nftnl::AllocationError> for Error {
+    fn from(error: nftnl::AllocationError) -> Self {
         Error(error.to_string())
     }
 }

--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -25,6 +25,7 @@
 use nftnl::{nft_expr, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
 use std::{ffi::CString, io};
 
+
 const TABLE_NAME: &str = "example-filter-ethernet";
 const OUT_CHAIN_NAME: &str = "chain-for-outgoing-packets";
 

--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -34,33 +34,33 @@ const BLOCK_THIS_MAC: &[u8] = &[0, 0, 0, 0, 0, 0];
 fn main() -> Result<(), Error> {
     // For verbose explanations of what all these lines up until the rule creation does, see the
     // `add-rules` example.
-    let mut batch = Batch::new()?;
-    let table = Table::new(&CString::new(TABLE_NAME).unwrap(), ProtoFamily::Inet)?;
-    batch.add(&table, nftnl::MsgType::Add)?;
+    let mut batch = Batch::new();
+    let table = Table::new(&CString::new(TABLE_NAME).unwrap(), ProtoFamily::Inet);
+    batch.add(&table, nftnl::MsgType::Add);
 
-    let mut out_chain = Chain::new(&CString::new(OUT_CHAIN_NAME).unwrap(), &table)?;
+    let mut out_chain = Chain::new(&CString::new(OUT_CHAIN_NAME).unwrap(), &table);
     out_chain.set_hook(nftnl::Hook::Out, 3);
     out_chain.set_policy(nftnl::Policy::Accept);
-    batch.add(&out_chain, nftnl::MsgType::Add)?;
+    batch.add(&out_chain, nftnl::MsgType::Add);
 
 
     // === ADD RULE DROPPING ALL TRAFFIC TO THE MAC ADDRESS IN `BLOCK_THIS_MAC` ===
 
-    let mut block_ethernet_rule = Rule::new(&out_chain)?;
+    let mut block_ethernet_rule = Rule::new(&out_chain);
 
     // Check that the interface type is an ethernet interface. Must be done before we can check
     // payload values in the ethernet header.
-    block_ethernet_rule.add_expr(&nft_expr!(meta iiftype))?;
-    block_ethernet_rule.add_expr(&nft_expr!(cmp == libc::ARPHRD_ETHER))?;
+    block_ethernet_rule.add_expr(&nft_expr!(meta iiftype));
+    block_ethernet_rule.add_expr(&nft_expr!(cmp == libc::ARPHRD_ETHER));
 
     // Compare the ethernet destination address against the MAC address we want to drop
-    block_ethernet_rule.add_expr(&nft_expr!(payload ethernet daddr))?;
-    block_ethernet_rule.add_expr(&nft_expr!(cmp == BLOCK_THIS_MAC))?;
+    block_ethernet_rule.add_expr(&nft_expr!(payload ethernet daddr));
+    block_ethernet_rule.add_expr(&nft_expr!(cmp == BLOCK_THIS_MAC));
 
     // Drop the matching packets.
-    block_ethernet_rule.add_expr(&nft_expr!(verdict drop))?;
+    block_ethernet_rule.add_expr(&nft_expr!(verdict drop));
 
-    batch.add(&block_ethernet_rule, nftnl::MsgType::Add)?;
+    batch.add(&block_ethernet_rule, nftnl::MsgType::Add);
 
 
     // === FOR FUN, ADD A PACKET THAT MATCHES 50% OF ALL PACKETS ===
@@ -69,24 +69,24 @@ fn main() -> Result<(), Error> {
     // So after a number of packets has passed through this rule, the first counter should have a
     // value approximately double that of the second counter. This rule has no verdict, so it never
     // does anything with the matching packets.
-    let mut random_rule = Rule::new(&out_chain)?;
+    let mut random_rule = Rule::new(&out_chain);
     // This counter expression will be evaluated (and increment the counter) for all packets coming
     // through.
-    random_rule.add_expr(&nft_expr!(counter))?;
+    random_rule.add_expr(&nft_expr!(counter));
 
     // Load a pseudo-random 32 bit unsigned integer into the netfilter register.
-    random_rule.add_expr(&nft_expr!(meta random))?;
+    random_rule.add_expr(&nft_expr!(meta random));
     // Check if the random integer is larger than `u32::MAX/2`, thus having 50% chance of success.
-    random_rule.add_expr(&nft_expr!(cmp > (::std::u32::MAX / 2).to_be()))?;
+    random_rule.add_expr(&nft_expr!(cmp > (::std::u32::MAX / 2).to_be()));
 
     // Add a second counter. This will only be incremented for the packets passing the random check.
-    random_rule.add_expr(&nft_expr!(counter))?;
+    random_rule.add_expr(&nft_expr!(counter));
 
-    batch.add(&random_rule, nftnl::MsgType::Add)?;
+    batch.add(&random_rule, nftnl::MsgType::Add);
 
     // === FINALIZE THE TRANSACTION AND SEND THE DATA TO NETFILTER ===
 
-    let finalized_batch = batch.finalize()?;
+    let finalized_batch = batch.finalize();
     send_and_process(&finalized_batch)?;
     Ok(())
 }
@@ -124,12 +124,6 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
 
 #[derive(Debug)]
 struct Error(String);
-
-impl From<nftnl::AllocationError> for Error {
-    fn from(error: nftnl::AllocationError) -> Self {
-        Error(error.to_string())
-    }
-}
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -78,7 +78,7 @@ impl Batch {
 
     fn next(&mut self) -> Result<()> {
         if unsafe { sys::nftnl_batch_update(self.batch) } < 0 {
-            return Err(crate::Error::AllocationError);
+            return Err(crate::AllocationError(()));
         }
         self.seq += 1;
         Ok(())

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,7 +1,6 @@
+use crate::{MsgType, NlMsg, Result};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
-
-use crate::{MsgType, NlMsg, Result};
 use std::ptr;
 
 /// Error while communicating with netlink

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -77,7 +77,8 @@ impl Batch {
 
     fn next(&mut self) {
         if unsafe { sys::nftnl_batch_update(self.batch) } < 0 {
-            panic!("Unable to allocate memory in libnftnl");
+            // See try_alloc definition.
+            std::process::abort();
         }
         self.seq += 1;
     }

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,4 +1,4 @@
-use crate::{MsgType, NlMsg, Result};
+use crate::{MsgType, NlMsg};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
 use std::ptr;
@@ -28,22 +28,22 @@ impl Batch {
     /// Creates a new nftnl batch with the [default page size].
     ///
     /// [default page size]: fn.default_batch_page_size.html
-    pub fn new() -> Result<Self> {
+    pub fn new() -> Self {
         Self::with_page_size(default_batch_page_size())
     }
 
     /// Creates a new nftnl batch with the given batch size.
-    pub fn with_page_size(batch_page_size: u32) -> Result<Self> {
+    pub fn with_page_size(batch_page_size: u32) -> Self {
         let batch = try_alloc!(unsafe {
             sys::nftnl_batch_alloc(batch_page_size, crate::nft_nlmsg_maxsize())
         });
         let mut this = Batch { batch, seq: 1 };
-        this.write_begin_msg()?;
-        Ok(this)
+        this.write_begin_msg();
+        this
     }
 
     /// Adds the given message to this batch.
-    pub fn add<T: NlMsg>(&mut self, msg: &T, msg_type: MsgType) -> Result<()> {
+    pub fn add<T: NlMsg>(&mut self, msg: &T, msg_type: MsgType) {
         trace!("Writing NlMsg with seq {} to batch", self.seq);
         unsafe { msg.write(self.current(), self.seq, msg_type) };
         self.next()
@@ -52,46 +52,44 @@ impl Batch {
     /// Adds all the messages in the given iterator to this batch. If any message fails to be added
     /// the error for that failure is returned and all messages up until that message stays added
     /// to the batch.
-    pub fn add_iter<T, I>(&mut self, msg_iter: I, msg_type: MsgType) -> Result<()>
+    pub fn add_iter<T, I>(&mut self, msg_iter: I, msg_type: MsgType)
     where
         T: NlMsg,
         I: Iterator<Item = T>,
     {
         for msg in msg_iter {
-            self.add(&msg, msg_type)?;
+            self.add(&msg, msg_type);
         }
-        Ok(())
     }
 
     /// Adds the final end message to the batch and returns a [`FinalizedBatch`] that can be used
     /// to send the messages to netfilter.
     ///
     /// [`FinalizedBatch`]: struct.FinalizedBatch.html
-    pub fn finalize(mut self) -> Result<FinalizedBatch> {
-        self.write_end_msg()?;
-        Ok(FinalizedBatch { batch: self })
+    pub fn finalize(mut self) -> FinalizedBatch {
+        self.write_end_msg();
+        FinalizedBatch { batch: self }
     }
 
     fn current(&self) -> *mut c_void {
         unsafe { sys::nftnl_batch_buffer(self.batch) }
     }
 
-    fn next(&mut self) -> Result<()> {
+    fn next(&mut self) {
         if unsafe { sys::nftnl_batch_update(self.batch) } < 0 {
-            return Err(crate::AllocationError(()));
+            panic!("Unable to allocate memory in libnftnl");
         }
         self.seq += 1;
-        Ok(())
     }
 
-    fn write_begin_msg(&mut self) -> Result<()> {
+    fn write_begin_msg(&mut self) {
         unsafe { sys::nftnl_batch_begin(self.current() as *mut i8, self.seq) };
-        self.next()
+        self.next();
     }
 
-    fn write_end_msg(&mut self) -> Result<()> {
+    fn write_end_msg(&mut self) {
         unsafe { sys::nftnl_batch_end(self.current() as *mut i8, self.seq) };
-        self.next()
+        self.next();
     }
 
     /// Returns the underlying `nftnl_batch` instance.

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,4 +1,4 @@
-use crate::{MsgType, Result, Table};
+use crate::{MsgType, Table};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
 use std::ffi::CStr;
@@ -50,7 +50,7 @@ impl<'a> Chain<'a> {
     /// Creates a new chain instance inside the given [`Table`] and with the given name.
     ///
     /// [`Table`]: struct.Table.html
-    pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Result<Chain<'a>> {
+    pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Chain<'a> {
         unsafe {
             let chain = try_alloc!(sys::nftnl_chain_alloc());
             sys::nftnl_chain_set_str(
@@ -59,7 +59,7 @@ impl<'a> Chain<'a> {
                 table.get_name().as_ptr(),
             );
             sys::nftnl_chain_set_str(chain, sys::NFTNL_CHAIN_NAME as u16, name.as_ref().as_ptr());
-            Ok(Chain { chain, table })
+            Chain { chain, table }
         }
     }
 

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,10 +1,7 @@
+use crate::{MsgType, Result, Table};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
-
 use std::ffi::CStr;
-
-use crate::Table;
-use crate::{MsgType, Result};
 
 
 pub type Priority = u32;

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -4,7 +4,7 @@ use nftnl_sys::{self as sys, libc::c_void};
 use std::ffi::CStr;
 
 use crate::Table;
-use crate::{ErrorKind, MsgType, Result};
+use crate::{MsgType, Result};
 
 
 pub type Priority = u32;
@@ -55,9 +55,7 @@ impl<'a> Chain<'a> {
     /// [`Table`]: struct.Table.html
     pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Result<Chain<'a>> {
         unsafe {
-            let chain = sys::nftnl_chain_alloc();
-            ensure!(!chain.is_null(), ErrorKind::AllocationError);
-
+            let chain = try_alloc!(sys::nftnl_chain_alloc());
             sys::nftnl_chain_set_str(
                 chain,
                 sys::NFTNL_CHAIN_TABLE as u16,

--- a/nftnl/src/expr/bitwise.rs
+++ b/nftnl/src/expr/bitwise.rs
@@ -1,11 +1,10 @@
+use super::Expression;
+use crate::expr::cmp::ToSlice;
 use libc;
 use nftnl_sys::{
     self as sys,
     libc::{c_char, c_void},
 };
-
-use super::Expression;
-use crate::expr::cmp::ToSlice;
 
 /// Expression for performing bitwise masking and XOR on the data in a register.
 pub struct Bitwise<M: ToSlice, X: ToSlice> {

--- a/nftnl/src/expr/bitwise.rs
+++ b/nftnl/src/expr/bitwise.rs
@@ -6,7 +6,6 @@ use nftnl_sys::{
 
 use super::Expression;
 use crate::expr::cmp::ToSlice;
-use crate::{ErrorKind, Result};
 
 /// Expression for performing bitwise masking and XOR on the data in a register.
 pub struct Bitwise<M: ToSlice, X: ToSlice> {
@@ -23,10 +22,11 @@ impl<M: ToSlice, X: ToSlice> Bitwise<M, X> {
 }
 
 impl<M: ToSlice, X: ToSlice> Expression for Bitwise<M, X> {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"bitwise\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"bitwise\0" as *const _ as *const c_char
+            ));
 
             let mask = self.mask.to_slice();
             let xor = self.xor.to_slice();

--- a/nftnl/src/expr/bitwise.rs
+++ b/nftnl/src/expr/bitwise.rs
@@ -21,7 +21,7 @@ impl<M: ToSlice, X: ToSlice> Bitwise<M, X> {
 }
 
 impl<M: ToSlice, X: ToSlice> Expression for Bitwise<M, X> {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"bitwise\0" as *const _ as *const c_char
@@ -57,7 +57,7 @@ impl<M: ToSlice, X: ToSlice> Expression for Bitwise<M, X> {
                 len,
             );
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -10,7 +10,6 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::slice;
 
 use super::Expression;
-use crate::{ErrorKind, Result};
 
 /// Comparison operator.
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -60,10 +59,9 @@ impl<T: ToSlice> Cmp<T> {
 }
 
 impl<T: ToSlice> Expression for Cmp<T> {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const c_char));
 
             let data = self.data.to_slice();
             trace!("Creating a cmp expr comparing with data {:?}", data);

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -59,7 +59,7 @@ impl<T: ToSlice> Cmp<T> {
 }
 
 impl<T: ToSlice> Expression for Cmp<T> {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(b"cmp\0" as *const _ as *const c_char));
 
@@ -79,7 +79,7 @@ impl<T: ToSlice> Expression for Cmp<T> {
                 data.len() as u32,
             );
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -1,15 +1,15 @@
+use super::Expression;
 use libc;
 use nftnl_sys::{
     self as sys,
     libc::{c_char, c_void},
 };
-
-use std::borrow::Cow;
-use std::ffi::CString;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::slice;
-
-use super::Expression;
+use std::{
+    borrow::Cow,
+    ffi::CString,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    slice,
+};
 
 /// Comparison operator.
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -6,9 +6,7 @@ use nftnl_sys::{self as sys, libc::c_char};
 pub struct Counter;
 
 impl Expression for Counter {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
-        Ok(try_alloc!(unsafe {
-            sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char)
-        }))
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
+        try_alloc!(unsafe { sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char) })
     }
 }

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -1,5 +1,4 @@
 use super::Expression;
-use crate::{ErrorKind, Result};
 use nftnl_sys::{self as sys, libc::c_char};
 
 /// A counter expression adds a counter to the rule that is incremented to count number of packets
@@ -7,11 +6,9 @@ use nftnl_sys::{self as sys, libc::c_char};
 pub struct Counter;
 
 impl Expression for Counter {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
-        unsafe {
-            let expr = sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
-            Ok(expr)
-        }
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+        Ok(try_alloc!(unsafe {
+            sys::nftnl_expr_alloc(b"counter\0" as *const _ as *const c_char)
+        }))
     }
 }

--- a/nftnl/src/expr/ct.rs
+++ b/nftnl/src/expr/ct.rs
@@ -25,14 +25,14 @@ impl Conntrack {
 }
 
 impl Expression for Conntrack {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(b"ct\0" as *const _ as *const c_char));
 
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_DREG as u16, libc::NFT_REG_1 as u32);
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_KEY as u16, self.raw_key());
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/ct.rs
+++ b/nftnl/src/expr/ct.rs
@@ -2,7 +2,6 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_char};
 
 use super::Expression;
-use crate::{ErrorKind, Result};
 
 bitflags::bitflags! {
     pub struct States: u32 {
@@ -27,10 +26,9 @@ impl Conntrack {
 }
 
 impl Expression for Conntrack {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"ct\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(b"ct\0" as *const _ as *const c_char));
 
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_DREG as u16, libc::NFT_REG_1 as u32);
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_KEY as u16, self.raw_key());

--- a/nftnl/src/expr/ct.rs
+++ b/nftnl/src/expr/ct.rs
@@ -1,7 +1,6 @@
+use super::Expression;
 use libc;
 use nftnl_sys::{self as sys, libc::c_char};
-
-use super::Expression;
 
 bitflags::bitflags! {
     pub struct States: u32 {

--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -2,7 +2,6 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_char};
 
 use super::Expression;
-use crate::{ErrorKind, Result};
 
 use std::ffi::{CStr, CString};
 
@@ -50,10 +49,11 @@ impl Verdict {
 }
 
 impl Expression for Verdict {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"immediate\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"immediate\0" as *const _ as *const c_char
+            ));
 
             sys::nftnl_expr_set_u32(
                 expr,

--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -1,8 +1,6 @@
+use super::Expression;
 use libc;
 use nftnl_sys::{self as sys, libc::c_char};
-
-use super::Expression;
-
 use std::ffi::{CStr, CString};
 
 /// A verdict expression. In the background actually an "Immediate" expression in nftnl terms,

--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -47,7 +47,7 @@ impl Verdict {
 }
 
 impl Expression for Verdict {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"immediate\0" as *const _ as *const c_char
@@ -68,7 +68,7 @@ impl Expression for Verdict {
                 self.verdict_const() as u32,
             );
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/lookup.rs
+++ b/nftnl/src/expr/lookup.rs
@@ -5,7 +5,6 @@ use std::ffi::CString;
 
 use super::Expression;
 use crate::set::Set;
-use crate::{ErrorKind, Result};
 
 pub struct Lookup {
     set_name: CString,
@@ -22,10 +21,11 @@ impl Lookup {
 }
 
 impl Expression for Lookup {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"lookup\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"lookup\0" as *const _ as *const c_char
+            ));
 
             sys::nftnl_expr_set_u32(
                 expr,

--- a/nftnl/src/expr/lookup.rs
+++ b/nftnl/src/expr/lookup.rs
@@ -1,10 +1,8 @@
-use libc;
-use nftnl_sys::{self as sys, libc::c_char};
-
-use std::ffi::CString;
-
 use super::Expression;
 use crate::set::Set;
+use libc;
+use nftnl_sys::{self as sys, libc::c_char};
+use std::ffi::CString;
 
 pub struct Lookup {
     set_name: CString,

--- a/nftnl/src/expr/lookup.rs
+++ b/nftnl/src/expr/lookup.rs
@@ -19,7 +19,7 @@ impl Lookup {
 }
 
 impl Expression for Lookup {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"lookup\0" as *const _ as *const c_char
@@ -43,7 +43,7 @@ impl Expression for Lookup {
             //         libc::NFT_LOOKUP_F_INV as u32);
             // }
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -1,7 +1,6 @@
+use super::Expression;
 use libc;
 use nftnl_sys::{self as sys, libc::c_char};
-
-use super::Expression;
 
 /// A meta expression refers to meta data associated with a packet.
 pub enum Meta {

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -2,7 +2,6 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_char};
 
 use super::Expression;
-use crate::{ErrorKind, Result};
 
 /// A meta expression refers to meta data associated with a packet.
 pub enum Meta {
@@ -48,10 +47,11 @@ impl Meta {
 }
 
 impl Expression for Meta {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"meta\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"meta\0" as *const _ as *const c_char
+            ));
 
             sys::nftnl_expr_set_u32(
                 expr,

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -46,7 +46,7 @@ impl Meta {
 }
 
 impl Expression for Meta {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"meta\0" as *const _ as *const c_char
@@ -58,7 +58,7 @@ impl Expression for Meta {
                 libc::NFT_REG_1 as u32,
             );
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_META_KEY as u16, self.to_raw_key());
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -9,7 +9,7 @@ use nftnl_sys as sys;
 pub trait Expression {
     /// Allocates and returns the low level `nftnl_expr` representation of this expression.
     /// The caller to this method is responsible for freeing the expression.
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr>;
+    fn to_expr(&self) -> *mut sys::nftnl_expr;
 }
 
 mod bitwise;

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -5,13 +5,11 @@
 
 use nftnl_sys as sys;
 
-use crate::Result;
-
 /// Trait for every safe wrapper of an nftables expression.
 pub trait Expression {
     /// Allocates and returns the low level `nftnl_expr` representation of this expression.
     /// The caller to this method is responsible for freeing the expression.
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr>;
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr>;
 }
 
 mod bitwise;

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -1,7 +1,6 @@
+use super::Expression;
 use libc;
 use nftnl_sys::{self as sys, libc::c_char};
-
-use super::Expression;
 
 trait HeaderField {
     fn offset(&self) -> u32;

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -2,7 +2,6 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_char};
 
 use super::Expression;
-use crate::{ErrorKind, Result};
 
 trait HeaderField {
     fn offset(&self) -> u32;
@@ -49,10 +48,11 @@ impl HeaderField for Payload {
 }
 
 impl Expression for Payload {
-    fn to_expr(&self) -> Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
         unsafe {
-            let expr = sys::nftnl_expr_alloc(b"payload\0" as *const _ as *const c_char);
-            ensure!(!expr.is_null(), ErrorKind::AllocationError);
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"payload\0" as *const _ as *const c_char
+            ));
 
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_PAYLOAD_BASE as u16, self.base());
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_PAYLOAD_OFFSET as u16, self.offset());

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -47,7 +47,7 @@ impl HeaderField for Payload {
 }
 
 impl Expression for Payload {
-    fn to_expr(&self) -> crate::Result<*mut sys::nftnl_expr> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
         unsafe {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"payload\0" as *const _ as *const c_char
@@ -62,7 +62,7 @@ impl Expression for Payload {
                 libc::NFT_REG_1 as u32,
             );
 
-            Ok(expr)
+            expr
         }
     }
 }

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -41,19 +41,11 @@ extern crate log;
 pub use nftnl_sys;
 use nftnl_sys::libc::c_void;
 
-
-pub type Result<T> = std::result::Result<T, AllocationError>;
-
-/// Unable to allocate memory
-#[derive(err_derive::Error, Debug)]
-#[error(display = "Unable to allocate memory")]
-pub struct AllocationError(());
-
 macro_rules! try_alloc {
     ($e:expr) => {{
         let ptr = $e;
         if ptr.is_null() {
-            return Err($crate::AllocationError(()));
+            panic!("Unable to allocate memory in libnftnl");
         }
         ptr
     }};

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -37,22 +37,31 @@
 pub use nftnl_sys;
 
 #[macro_use]
-extern crate error_chain;
-#[macro_use]
 extern crate log;
 
 use nftnl_sys::libc::c_void;
 
-pub use error_chain::ChainedError;
-error_chain! {
-    errors {
-        /// Unable to allocate memory
-        AllocationError { description("Unable to allocate memory") }
-        /// Not enough room in the batch
-        BatchIsFull { description("Not enough room in the batch") }
-        /// Error while communicating with netlink
-        NetlinkError { description("Error while communicating with netlink") }
-    }
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Unable to allocate memory
+    #[error(display = "Unable to allocate memory")]
+    AllocationError,
+
+    /// Not enough room in the batch
+    #[error(display = "Not enough room in the batch")]
+    BatchIsFull,
+}
+
+macro_rules! try_alloc {
+    ($e:expr) => {{
+        let ptr = $e;
+        if ptr.is_null() {
+            return Err($crate::Error::AllocationError);
+        }
+        ptr
+    }};
 }
 
 mod batch;

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -52,7 +52,7 @@ macro_rules! try_alloc {
 }
 
 mod batch;
-pub use batch::{batch_is_supported, default_batch_page_size, Batch, FinalizedBatch};
+pub use batch::{batch_is_supported, default_batch_page_size, Batch, FinalizedBatch, NetlinkError};
 
 pub mod expr;
 

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -34,12 +34,13 @@
 //! [`nftables`]: https://netfilter.org/projects/nftables/
 //! [`nftnl-sys`]: https://crates.io/crates/nftnl-sys
 
-pub use nftnl_sys;
-
 #[macro_use]
 extern crate log;
 
+
+pub use nftnl_sys;
 use nftnl_sys::libc::c_void;
+
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -45,7 +45,9 @@ macro_rules! try_alloc {
     ($e:expr) => {{
         let ptr = $e;
         if ptr.is_null() {
-            panic!("Unable to allocate memory in libnftnl");
+            // OOM, and the tried allocation was likely very small,
+            // so we are in a very tight situation. We do what libstd does, aborts.
+            std::process::abort();
         }
         ptr
     }};

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -42,24 +42,18 @@ pub use nftnl_sys;
 use nftnl_sys::libc::c_void;
 
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, AllocationError>;
 
+/// Unable to allocate memory
 #[derive(err_derive::Error, Debug)]
-pub enum Error {
-    /// Unable to allocate memory
-    #[error(display = "Unable to allocate memory")]
-    AllocationError,
-
-    /// Not enough room in the batch
-    #[error(display = "Not enough room in the batch")]
-    BatchIsFull,
-}
+#[error(display = "Unable to allocate memory")]
+pub struct AllocationError(());
 
 macro_rules! try_alloc {
     ($e:expr) => {{
         let ptr = $e;
         if ptr.is_null() {
-            return Err($crate::Error::AllocationError);
+            return Err($crate::AllocationError(()));
         }
         ptr
     }};

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -1,9 +1,6 @@
+use crate::{chain::Chain, expr::Expression, MsgType, Result};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
-
-use crate::chain::Chain;
-use crate::expr::Expression;
-use crate::{MsgType, Result};
 
 /// A nftables firewall rule.
 pub struct Rule<'a> {

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -1,4 +1,4 @@
-use crate::{chain::Chain, expr::Expression, MsgType, Result};
+use crate::{chain::Chain, expr::Expression, MsgType};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
 
@@ -12,7 +12,7 @@ impl<'a> Rule<'a> {
     /// Creates a new rule object in the given [`Chain`].
     ///
     /// [`Chain`]: struct.Chain.html
-    pub fn new(chain: &'a Chain<'_>) -> Result<Rule<'a>> {
+    pub fn new(chain: &'a Chain<'_>) -> Rule<'a> {
         unsafe {
             let rule = try_alloc!(sys::nftnl_rule_alloc());
             sys::nftnl_rule_set_str(
@@ -31,7 +31,7 @@ impl<'a> Rule<'a> {
                 chain.get_table().get_family() as u32,
             );
 
-            Ok(Rule { rule, chain })
+            Rule { rule, chain }
         }
     }
 
@@ -52,9 +52,8 @@ impl<'a> Rule<'a> {
     /// Adds an expression to this rule. Expressions are evaluated from first to last added.
     /// As soon as an expression does not match the packet it's being evaluated for, evaluation
     /// stops and the packet is evaluated against the next rule in the chain.
-    pub fn add_expr(&mut self, expr: &impl Expression) -> Result<()> {
-        unsafe { sys::nftnl_rule_add_expr(self.rule, expr.to_expr()?) }
-        Ok(())
+    pub fn add_expr(&mut self, expr: &impl Expression) {
+        unsafe { sys::nftnl_rule_add_expr(self.rule, expr.to_expr()) }
     }
 
     /// Returns a reference to the [`Chain`] this rule lives in.

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -3,7 +3,7 @@ use nftnl_sys::{self as sys, libc::c_void};
 
 use crate::chain::Chain;
 use crate::expr::Expression;
-use crate::{ErrorKind, MsgType, Result};
+use crate::{MsgType, Result};
 
 /// A nftables firewall rule.
 pub struct Rule<'a> {
@@ -17,9 +17,7 @@ impl<'a> Rule<'a> {
     /// [`Chain`]: struct.Chain.html
     pub fn new(chain: &'a Chain<'_>) -> Result<Rule<'a>> {
         unsafe {
-            let rule = sys::nftnl_rule_alloc();
-            ensure!(!rule.is_null(), ErrorKind::AllocationError);
-
+            let rule = try_alloc!(sys::nftnl_rule_alloc());
             sys::nftnl_rule_set_str(
                 rule,
                 sys::NFTNL_RULE_TABLE as u16,

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -2,7 +2,7 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_void};
 
 use crate::table::Table;
-use crate::{ErrorKind, MsgType, ProtoFamily, Result};
+use crate::{MsgType, ProtoFamily, Result};
 use std::cell::Cell;
 use std::ffi::CStr;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -39,8 +39,7 @@ impl<'a, K> Set<'a, K> {
         K: SetKey,
     {
         unsafe {
-            let set = sys::nftnl_set_alloc();
-            ensure!(!set.is_null(), ErrorKind::AllocationError);
+            let set = try_alloc!(sys::nftnl_set_alloc());
 
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_FAMILY as u16, family as u32);
             sys::nftnl_set_set_str(set, sys::NFTNL_SET_TABLE as u16, table.get_name().as_ptr());
@@ -69,8 +68,7 @@ impl<'a, K> Set<'a, K> {
         K: SetKey,
     {
         unsafe {
-            let elem = sys::nftnl_set_elem_alloc();
-            ensure!(!elem.is_null(), ErrorKind::AllocationError);
+            let elem = try_alloc!(sys::nftnl_set_elem_alloc());
 
             let data = key.data();
             let data_len = data.len() as u32;
@@ -141,8 +139,7 @@ pub struct SetElemsIter<'a, K> {
 
 impl<'a, K> SetElemsIter<'a, K> {
     fn new(set: &'a Set<'a, K>) -> Result<Self> {
-        let iter = unsafe { sys::nftnl_set_elems_iter_create(set.as_ptr()) };
-        ensure!(!iter.is_null(), ErrorKind::AllocationError);
+        let iter = try_alloc!(unsafe { sys::nftnl_set_elems_iter_create(set.as_ptr()) });
 
         Ok(SetElemsIter {
             set,

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -1,4 +1,4 @@
-use crate::{table::Table, MsgType, ProtoFamily, Result};
+use crate::{table::Table, MsgType, ProtoFamily};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
 use std::{
@@ -34,7 +34,7 @@ pub struct Set<'a, K> {
 }
 
 impl<'a, K> Set<'a, K> {
-    pub fn new(name: &CStr, id: u32, table: &'a Table, family: ProtoFamily) -> Result<Self>
+    pub fn new(name: &CStr, id: u32, table: &'a Table, family: ProtoFamily) -> Self
     where
         K: SetKey,
     {
@@ -54,16 +54,16 @@ impl<'a, K> Set<'a, K> {
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_TYPE as u16, K::TYPE);
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_LEN as u16, K::LEN);
 
-            Ok(Set {
+            Set {
                 set,
                 table,
                 family,
                 _marker: ::std::marker::PhantomData,
-            })
+            }
         }
     }
 
-    pub fn add(&mut self, key: &K) -> Result<()>
+    pub fn add(&mut self, key: &K)
     where
         K: SetKey,
     {
@@ -81,10 +81,9 @@ impl<'a, K> Set<'a, K> {
             );
             sys::nftnl_set_elem_add(self.set, elem);
         }
-        Ok(())
     }
 
-    pub fn elems_iter(&'a self) -> Result<SetElemsIter<'a, K>> {
+    pub fn elems_iter(&'a self) -> SetElemsIter<'a, K> {
         SetElemsIter::new(self)
     }
 
@@ -138,14 +137,13 @@ pub struct SetElemsIter<'a, K> {
 }
 
 impl<'a, K> SetElemsIter<'a, K> {
-    fn new(set: &'a Set<'a, K>) -> Result<Self> {
+    fn new(set: &'a Set<'a, K>) -> Self {
         let iter = try_alloc!(unsafe { sys::nftnl_set_elems_iter_create(set.as_ptr()) });
-
-        Ok(SetElemsIter {
+        SetElemsIter {
             set,
             iter,
             ret: Rc::new(Cell::new(1)),
-        })
+        }
     }
 }
 

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -1,12 +1,12 @@
+use crate::{table::Table, MsgType, ProtoFamily, Result};
 use libc;
 use nftnl_sys::{self as sys, libc::c_void};
-
-use crate::table::Table;
-use crate::{MsgType, ProtoFamily, Result};
-use std::cell::Cell;
-use std::ffi::CStr;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::rc::Rc;
+use std::{
+    cell::Cell,
+    ffi::CStr,
+    net::{Ipv4Addr, Ipv6Addr},
+    rc::Rc,
+};
 
 
 #[macro_export]

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -1,4 +1,4 @@
-use crate::{MsgType, ProtoFamily, Result};
+use crate::{MsgType, ProtoFamily};
 use nftnl_sys::{
     self as sys,
     libc::{self, c_void},
@@ -20,13 +20,13 @@ pub struct Table {
 
 impl Table {
     /// Creates a new table instance with the given name and protocol family.
-    pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Result<Table> {
+    pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Table {
         unsafe {
             let table = try_alloc!(sys::nftnl_table_alloc());
 
             sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
             sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FAMILY as u16, family as u32);
-            Ok(Table { table, family })
+            Table { table, family }
         }
     }
 

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -1,14 +1,12 @@
+use crate::{MsgType, ProtoFamily, Result};
 use nftnl_sys::{
     self as sys,
     libc::{self, c_void},
 };
-
 use std::{
     collections::HashSet,
     ffi::{CStr, CString},
 };
-
-use crate::{MsgType, ProtoFamily, Result};
 
 
 /// Abstraction of `nftnl_table`. The top level container in netfilter. A table has a protocol

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -8,7 +8,7 @@ use std::{
     ffi::{CStr, CString},
 };
 
-use crate::{ErrorKind, MsgType, ProtoFamily, Result};
+use crate::{MsgType, ProtoFamily, Result};
 
 
 /// Abstraction of `nftnl_table`. The top level container in netfilter. A table has a protocol
@@ -24,8 +24,7 @@ impl Table {
     /// Creates a new table instance with the given name and protocol family.
     pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Result<Table> {
         unsafe {
-            let table = sys::nftnl_table_alloc();
-            ensure!(!table.is_null(), ErrorKind::AllocationError);
+            let table = try_alloc!(sys::nftnl_table_alloc());
 
             sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
             sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FAMILY as u16, family as u32);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,10 @@
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
+use_field_init_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true
 wrap_comments = true
+merge_imports = true
 
 # Heavily subjective style choices
 comment_width = 100


### PR DESCRIPTION
Removes the dependency on `error-chain` and replace it with `err-derive` errors.

One odd thing I found was that the `BatchIsFull` error variant was never used. OK, so we forgot to remove it when we stopped using it?... I can't see in the git history that we ever used it. Adding messages to batches has always just returned the allocation error, since adding stuff to batches only fails if `libnftnl` fails to allocate a new page for it.

With `BatchIsFull` removed and the netlink error separated, this brings us down to a single error that can happen. The Rust standard library just panics on allocation errors at the moment. Because there is not very much you can do anyway, so you probably want your thread to exit? So... Should we remove our `AllocationError` and change the `try_alloc!` macro to panic instead? Then usage of the library becomes infallible and the API a lot simpler.

I also did some small maintenance tasks. Updating the formatting to our latest rustfmt.toml version and reformatted. And upgraded a dev dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/21)
<!-- Reviewable:end -->
