### PR TITLE
Add support for reading ICMPv6 header fields

### DIFF
--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -182,6 +182,7 @@ impl HeaderField for Ipv6HeaderField {
 pub enum TransportHeaderField {
     Tcp(TcpHeaderField),
     Udp(UdpHeaderField),
+    Icmpv6(Icmpv6HeaderField),
 }
 
 impl HeaderField for TransportHeaderField {
@@ -190,6 +191,7 @@ impl HeaderField for TransportHeaderField {
         match *self {
             Tcp(ref f) => f.offset(),
             Udp(ref f) => f.offset(),
+            Icmpv6(ref f) => f.offset(),
         }
     }
 
@@ -198,6 +200,7 @@ impl HeaderField for TransportHeaderField {
         match *self {
             Tcp(ref f) => f.len(),
             Udp(ref f) => f.len(),
+            Icmpv6(ref f) => f.len(),
         }
     }
 }
@@ -249,6 +252,33 @@ impl HeaderField for UdpHeaderField {
             Sport => 2,
             Dport => 2,
             Len => 2,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum Icmpv6HeaderField {
+    Type,
+    Code,
+    Checksum,
+}
+
+impl HeaderField for Icmpv6HeaderField {
+    fn offset(&self) -> u32 {
+        use self::Icmpv6HeaderField::*;
+        match *self {
+            Type => 0,
+            Code => 1,
+            Checksum => 2,
+        }
+    }
+
+    fn len(&self) -> u32 {
+        use self::Icmpv6HeaderField::*;
+        match *self {
+            Type => 1,
+            Code => 1,
+            Checksum => 2,
         }
     }
 }


### PR DESCRIPTION
For router solicitation/advertisement we need to check the ICMPv6 type and code header fields in our firewall rules. This adds support for ICMPv6 transport header fields.

I also create a rule using this new feature in an example. To prove to myself that it works.

ICMPv6 header spec can be found here: https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol_for_IPv6#Message_types_and_formats

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/23)
<!-- Reviewable:end -->
