### PR TITLE
Add support for cgroups, ct and packet marks, and setting packet metainformation

### DIFF
--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -1,7 +1,46 @@
 use super::Expression;
 use libc;
-use nftnl_sys::{self as sys, libc::c_char};
-use std::ffi::{CStr, CString};
+use nftnl_sys::{self as sys, libc::{c_char, c_void}};
+use std::{ffi::{CStr, CString}, mem::size_of_val};
+
+/// An immediate expression. Used to set immediate data.
+/// Verdicts are handled separately by [Verdict].
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Immediate<T> {
+    pub data: T,
+}
+
+impl<T> Expression for Immediate<T> {
+    fn to_expr(&self) -> *mut sys::nftnl_expr {
+        unsafe {
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"immediate\0" as *const _ as *const c_char
+            ));
+
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_IMM_DREG as u16,
+                libc::NFT_REG_1 as u32,
+            );
+
+            sys::nftnl_expr_set(
+                expr,
+                sys::NFTNL_EXPR_IMM_DATA as u16,
+                &self.data as *const _ as *const c_void,
+                size_of_val(&self.data) as u32,
+            );
+
+            expr
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_immediate {
+    (data $value:expr) => {
+        $crate::expr::Immediate { data: $value }
+    };
+}
 
 /// A verdict expression. In the background actually an "Immediate" expression in nftnl terms,
 /// but here it's simplified to only represent a verdict.

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -22,6 +22,8 @@ pub enum Meta {
     NfProto,
     /// Layer 4 protocol number.
     L4Proto,
+    /// Socket control group (skb->sk->sk_classid).
+    Cgroup,
     /// A 32bit pseudo-random number
     PRandom,
 }
@@ -40,6 +42,7 @@ impl Meta {
             OifType => libc::NFT_META_OIFTYPE as u32,
             NfProto => libc::NFT_META_NFPROTO as u32,
             L4Proto => libc::NFT_META_L4PROTO as u32,
+            Cgroup => libc::NFT_META_CGROUP as u32,
             PRandom => libc::NFT_META_PRANDOM as u32,
         }
     }
@@ -91,6 +94,9 @@ macro_rules! nft_expr_meta {
     };
     (l4proto) => {
         $crate::expr::Meta::L4Proto
+    };
+    (cgroup) => {
+        $crate::expr::Meta::Cgroup
     };
     (random) => {
         $crate::expr::Meta::PRandom

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -6,6 +6,8 @@ use nftnl_sys::{self as sys, libc::c_char};
 pub enum Meta {
     /// Packet ethertype protocol (skb->protocol), invalid in OUTPUT.
     Protocol,
+    /// Packet mark.
+    Mark { set: bool },
     /// Packet input interface index (dev->ifindex).
     Iif,
     /// Packet output interface index (dev->ifindex).
@@ -31,9 +33,10 @@ pub enum Meta {
 impl Meta {
     /// Returns the corresponding `NFT_*` constant for this meta expression.
     pub fn to_raw_key(&self) -> u32 {
-        use self::Meta::*;
+        use Meta::*;
         match *self {
             Protocol => libc::NFT_META_PROTOCOL as u32,
+            Mark { .. } => libc::NFT_META_MARK as u32,
             Iif => libc::NFT_META_IIF as u32,
             Oif => libc::NFT_META_OIF as u32,
             IifName => libc::NFT_META_IIFNAME as u32,
@@ -55,11 +58,19 @@ impl Expression for Meta {
                 b"meta\0" as *const _ as *const c_char
             ));
 
-            sys::nftnl_expr_set_u32(
-                expr,
-                sys::NFTNL_EXPR_META_DREG as u16,
-                libc::NFT_REG_1 as u32,
-            );
+            if let Meta::Mark { set: true } = self {
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_META_SREG as u16,
+                    libc::NFT_REG_1 as u32,
+                );
+            } else {
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_META_DREG as u16,
+                    libc::NFT_REG_1 as u32,
+                );
+            }
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_META_KEY as u16, self.to_raw_key());
             expr
         }
@@ -70,6 +81,12 @@ impl Expression for Meta {
 macro_rules! nft_expr_meta {
     (proto) => {
         $crate::expr::Meta::Protocol
+    };
+    (mark set) => {
+        $crate::expr::Meta::Mark { set: true }
+    };
+    (mark) => {
+        $crate::expr::Meta::Mark { set: false }
     };
     (iif) => {
         $crate::expr::Meta::Iif

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -59,6 +59,9 @@ macro_rules! nft_expr {
     (lookup $set:expr) => {
         nft_expr_lookup!($set)
     };
+    (meta $expr:ident set) => {
+        nft_expr_meta!($expr set)
+    };
     (meta $expr:ident) => {
         nft_expr_meta!($expr)
     };

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -68,4 +68,7 @@ macro_rules! nft_expr {
     (payload $proto:ident $field:ident) => {
         nft_expr_payload!($proto $field)
     };
+    (immediate $expr:ident $value:expr) => {
+        nft_expr_immediate!($expr $value)
+    };
 }

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -22,7 +22,7 @@ mod counter;
 pub use self::counter::*;
 
 pub mod ct;
-pub use self::ct::Conntrack;
+pub use self::ct::*;
 
 mod immediate;
 pub use self::immediate::*;
@@ -46,6 +46,9 @@ macro_rules! nft_expr {
     };
     (counter) => {
         $crate::expr::Counter
+    };
+    (ct $key:ident set) => {
+        nft_expr_ct!($key set)
     };
     (ct $key:ident) => {
         nft_expr_ct!($key)


### PR DESCRIPTION
Changes:
* Add expressions `&nft_expr!(meta cgroup)` and `&nft_expr!(meta mark)`
* Set immediate data: `&nft_expr!(immediate data 1234)`
* Set packet metadata, e.g. `&nft_expr!(meta mark set)` (preceded by `immediate ...`)
* Support ct/connection marks: `&nft_expr!(ct mark)` and `&nft_expr!(ct mark set)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/24)
<!-- Reviewable:end -->
