### PR TITLE
Add base chain types

### DIFF
--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -62,7 +62,7 @@ pub mod table;
 pub use table::Table;
 
 mod chain;
-pub use chain::{Chain, Hook, Policy, Priority};
+pub use chain::{Chain, ChainType, Hook, Policy, Priority};
 
 mod rule;
 pub use rule::Rule;


### PR DESCRIPTION
In order to set packet marks, the base chain type must be set to [`route`](https://wiki.nftables.org/wiki-nftables/index.php/Configuring_chains) (rather than `filter`). This is done using `chain.set_base_type(type)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/25)
<!-- Reviewable:end -->
