### PR TITLE
List non-inet tables

### DIFF
--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -75,7 +75,7 @@ pub fn get_tables_nlmsg(seq: u32) -> Vec<u8> {
         sys::nftnl_nlmsg_build_hdr(
             buffer.as_mut_ptr() as *mut i8,
             libc::NFT_MSG_GETTABLE as u16,
-            ProtoFamily::Inet as u16,
+            ProtoFamily::Unspec as u16,
             (libc::NLM_F_ROOT | libc::NLM_F_MATCH) as u16,
             seq,
         )


### PR DESCRIPTION
Update the table list request to use the `unspec` protocol family. This means that tables for protocols `arp`, `ip`, `ip6`, `bridge`, etc., will also be included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/26)
<!-- Reviewable:end -->
