### PR TITLE
Fix flags and attributes

### DIFF
--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,7 +1,7 @@
 use crate::{MsgType, Table};
 use libc;
 use nftnl_sys::{self as sys, libc::{c_char, c_void}};
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 
 
 pub type Priority = i32;
@@ -116,6 +116,22 @@ impl<'a> Chain<'a> {
                 chain_type.as_c_str().as_ptr() as *const c_char
             );
         }
+    }
+
+    /// Return a string representation of the chain.
+    pub fn dump(&self) -> CString {
+        let mut buffer: [u8; 4096] = [0; 4096];
+        unsafe {
+            sys::nftnl_chain_snprintf(
+                buffer.as_mut_ptr() as *mut i8,
+                buffer.len(),
+                self.chain,
+                0,
+                0,
+            );
+        }
+        let null_index = buffer.iter().position(|ch| *ch == b'\0').unwrap();
+        CString::new(&buffer[0..null_index]).unwrap()
     }
 
     /// Sets the default policy for this chain. That means what action netfilter will apply to

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -166,11 +166,15 @@ unsafe impl<'a> crate::NlMsg for Chain<'a> {
             MsgType::Add => libc::NFT_MSG_NEWCHAIN,
             MsgType::Del => libc::NFT_MSG_DELCHAIN,
         };
+        let flags: u16 = match msg_type {
+            MsgType::Add => (libc::NLM_F_ACK | libc::NLM_F_CREATE) as u16,
+            MsgType::Del => libc::NLM_F_ACK as u16,
+        };
         let header = sys::nftnl_nlmsg_build_hdr(
             buf as *mut i8,
             raw_msg_type as u16,
             self.table.get_family() as u16,
-            libc::NLM_F_ACK as u16,
+            flags,
             seq,
         );
         sys::nftnl_chain_nlmsg_build_payload(header, self.chain);

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -4,7 +4,7 @@ use nftnl_sys::{self as sys, libc::{c_char, c_void}};
 use std::ffi::CStr;
 
 
-pub type Priority = u32;
+pub type Priority = i32;
 
 /// The netfilter event hooks a chain can register for.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -77,6 +77,11 @@ impl<'a> Chain<'a> {
     pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Chain<'a> {
         unsafe {
             let chain = try_alloc!(sys::nftnl_chain_alloc());
+            sys::nftnl_chain_set_u32(
+                chain,
+                sys::NFTNL_CHAIN_FAMILY as u16,
+                table.get_family() as u32,
+            );
             sys::nftnl_chain_set_str(
                 chain,
                 sys::NFTNL_CHAIN_TABLE as u16,
@@ -97,7 +102,7 @@ impl<'a> Chain<'a> {
     pub fn set_hook(&mut self, hook: Hook, priority: Priority) {
         unsafe {
             sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_HOOKNUM as u16, hook as u32);
-            sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_PRIO as u16, priority);
+            sys::nftnl_chain_set_s32(self.chain, sys::NFTNL_CHAIN_PRIO as u16, priority);
         }
     }
 

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -70,11 +70,15 @@ unsafe impl<'a> crate::NlMsg for Rule<'a> {
             MsgType::Add => libc::NFT_MSG_NEWRULE,
             MsgType::Del => libc::NFT_MSG_DELRULE,
         };
+        let flags: u16 = match msg_type {
+            MsgType::Add => (libc::NLM_F_CREATE | libc::NLM_F_APPEND | libc::NLM_F_EXCL) as u16,
+            MsgType::Del => 0u16,
+        };
         let header = sys::nftnl_nlmsg_build_hdr(
             buf as *mut i8,
             type_ as u16,
             self.chain.get_table().get_family() as u16,
-            (libc::NLM_F_APPEND | libc::NLM_F_CREATE | libc::NLM_F_EXCL) as u16,
+            flags,
             seq,
         );
         sys::nftnl_rule_nlmsg_build_payload(header, self.rule);

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -15,6 +15,11 @@ impl<'a> Rule<'a> {
     pub fn new(chain: &'a Chain<'_>) -> Rule<'a> {
         unsafe {
             let rule = try_alloc!(sys::nftnl_rule_alloc());
+            sys::nftnl_rule_set_u32(
+                rule,
+                sys::NFTNL_RULE_FAMILY as u16,
+                chain.get_table().get_family() as u32,
+            );
             sys::nftnl_rule_set_str(
                 rule,
                 sys::NFTNL_RULE_TABLE as u16,
@@ -24,11 +29,6 @@ impl<'a> Rule<'a> {
                 rule,
                 sys::NFTNL_RULE_CHAIN as u16,
                 chain.get_name().as_ptr(),
-            );
-            sys::nftnl_rule_set_u32(
-                rule,
-                sys::NFTNL_RULE_FAMILY as u16,
-                chain.get_table().get_family() as u32,
             );
 
             Rule { rule, chain }

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -24,8 +24,9 @@ impl Table {
         unsafe {
             let table = try_alloc!(sys::nftnl_table_alloc());
 
-            sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
             sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FAMILY as u16, family as u32);
+            sys::nftnl_table_set_str(table, sys::NFTNL_TABLE_NAME as u16, name.as_ref().as_ptr());
+            sys::nftnl_table_set_u32(table, sys::NFTNL_TABLE_FLAGS as u16, 0u32);
             Table { table, family }
         }
     }


### PR DESCRIPTION
One issue with older kernels stemmed from `NFTNL_CHAIN_FAMILY` not being set for chains. Some flags were updated as well.

Unrelatedly, add `Chain::dump` for producing a debug string representation of a chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/28)
<!-- Reviewable:end -->
