### PR TITLE
Fix compilation errors on ARM64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for masquerading.
 
+### Fixed
+- Fix compilation errors on ARM64 platforms.
+
 
 ## [0.2.1] - 2019-09-23
 ### Added

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,6 +1,6 @@
 use crate::{MsgType, NlMsg};
 use libc;
-use nftnl_sys::{self as sys, libc::c_void};
+use nftnl_sys::{self as sys, libc::{c_char, c_void}};
 use std::ptr;
 
 /// Error while communicating with netlink
@@ -84,12 +84,12 @@ impl Batch {
     }
 
     fn write_begin_msg(&mut self) {
-        unsafe { sys::nftnl_batch_begin(self.current() as *mut i8, self.seq) };
+        unsafe { sys::nftnl_batch_begin(self.current() as *mut c_char, self.seq) };
         self.next();
     }
 
     fn write_end_msg(&mut self) {
-        unsafe { sys::nftnl_batch_end(self.current() as *mut i8, self.seq) };
+        unsafe { sys::nftnl_batch_end(self.current() as *mut c_char, self.seq) };
         self.next();
     }
 

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -148,7 +148,7 @@ impl<'a> fmt::Debug for Chain<'a> {
         let mut buffer: [u8; 4096] = [0; 4096];
         unsafe {
             sys::nftnl_chain_snprintf(
-                buffer.as_mut_ptr() as *mut i8,
+                buffer.as_mut_ptr() as *mut c_char,
                 buffer.len(),
                 self.chain,
                 sys::NFTNL_OUTPUT_DEFAULT,
@@ -171,7 +171,7 @@ unsafe impl<'a> crate::NlMsg for Chain<'a> {
             MsgType::Del => libc::NLM_F_ACK as u16,
         };
         let header = sys::nftnl_nlmsg_build_hdr(
-            buf as *mut i8,
+            buf as *mut c_char,
             raw_msg_type as u16,
             self.table.get_family() as u16,
             flags,

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -1,6 +1,6 @@
 use crate::{chain::Chain, expr::Expression, MsgType};
 use libc;
-use nftnl_sys::{self as sys, libc::c_void};
+use nftnl_sys::{self as sys, libc::{c_char, c_void}};
 
 /// A nftables firewall rule.
 pub struct Rule<'a> {
@@ -75,7 +75,7 @@ unsafe impl<'a> crate::NlMsg for Rule<'a> {
             MsgType::Del => 0u16,
         };
         let header = sys::nftnl_nlmsg_build_hdr(
-            buf as *mut i8,
+            buf as *mut c_char,
             type_ as u16,
             self.chain.get_table().get_family() as u16,
             flags,

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -1,6 +1,6 @@
 use crate::{table::Table, MsgType, ProtoFamily};
 use libc;
-use nftnl_sys::{self as sys, libc::c_void};
+use nftnl_sys::{self as sys, libc::{c_char, c_void}};
 use std::{
     cell::Cell,
     ffi::CStr,
@@ -114,7 +114,7 @@ unsafe impl<'a, K> crate::NlMsg for Set<'a, K> {
             MsgType::Del => libc::NFT_MSG_DELSET,
         };
         let header = sys::nftnl_nlmsg_build_hdr(
-            buf as *mut i8,
+            buf as *mut c_char,
             type_ as u16,
             self.table.get_family() as u16,
             (libc::NLM_F_APPEND | libc::NLM_F_CREATE | libc::NLM_F_ACK) as u16,
@@ -188,7 +188,7 @@ unsafe impl<'a, K> crate::NlMsg for SetElemsMsg<'a, K> {
             MsgType::Del => (libc::NFT_MSG_DELSETELEM, libc::NLM_F_ACK),
         };
         let header = sys::nftnl_nlmsg_build_hdr(
-            buf as *mut i8,
+            buf as *mut c_char,
             type_ as u16,
             self.set.get_family() as u16,
             flags as u16,

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -1,7 +1,7 @@
 use crate::{MsgType, ProtoFamily};
 use nftnl_sys::{
     self as sys,
-    libc::{self, c_void},
+    libc::{self, c_char, c_void},
 };
 use std::{
     collections::HashSet,
@@ -52,7 +52,7 @@ unsafe impl crate::NlMsg for Table {
             MsgType::Del => libc::NFT_MSG_DELTABLE,
         };
         let header = sys::nftnl_nlmsg_build_hdr(
-            buf as *mut i8,
+            buf as *mut c_char,
             raw_msg_type as u16,
             self.family as u16,
             libc::NLM_F_ACK as u16,
@@ -74,7 +74,7 @@ pub fn get_tables_nlmsg(seq: u32) -> Vec<u8> {
     let mut buffer = vec![0; crate::nft_nlmsg_maxsize() as usize];
     let _ = unsafe {
         sys::nftnl_nlmsg_build_hdr(
-            buffer.as_mut_ptr() as *mut i8,
+            buffer.as_mut_ptr() as *mut c_char,
             libc::NFT_MSG_GETTABLE as u16,
             ProtoFamily::Unspec as u16,
             (libc::NLM_F_ROOT | libc::NLM_F_MATCH) as u16,


### PR DESCRIPTION
Fix compilation errors caused by `c_char` being defined as `u8` instead of `i8`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/30)
<!-- Reviewable:end -->
