### PR TITLE
Upgrade err derive

### DIFF
--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -26,5 +26,5 @@ log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.3" }
 
 [dev-dependencies]
-ipnetwork = "0.15"
-mnl = "0.1"
+ipnetwork = "0.16"
+mnl = "0.2"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -20,7 +20,7 @@ nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 
 [dependencies]
 bitflags = "1.0"
-err-derive = "0.1.5"
+err-derive = "0.2.4"
 libc = "0.2.40"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.3" }


### PR DESCRIPTION
`err-derive 0.1.6` is broken. And our version spec (`err-derive = "0.1.5"`) allowed the usage of it. So after a simple `cargo update` this crate broke. Here I upgrade it to the latest release from `0.2`.

I also upgrade other dependencies that were slightly outdated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/31)
<!-- Reviewable:end -->
