### PR TITLE
Prepare release and make enums non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+
+## [0.5.0] - 2020-06-04
 ### Added
 - Add support for matching on socket UID and socket GID in `Meta` expressions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for matching on socket UID and socket GID in `Meta` expressions.
 
+### Changed
+- Mark `Meta` and many payload enums as `#[non_exhaustive]`. Allows adding more expressions
+  without a breaking release in the future.
+- Increase minimum supported rust version to 1.40 due to `#[non_exhaustive]`.
+
 
 ## [0.4.0] - 2020-05-27
 ### Added

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl-sys"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN"]
 license = "MIT/Apache-2.0"
 description = "Low level FFI bindings to libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN"]
 license = "MIT/Apache-2.0"
 description = "Safe abstraction for libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"
@@ -23,7 +23,7 @@ bitflags = "1.0"
 err-derive = "0.2.4"
 libc = "0.2.40"
 log = "0.4"
-nftnl-sys = { path = "../nftnl-sys", version = "0.4" }
+nftnl-sys = { path = "../nftnl-sys", version = "0.5" }
 
 [dev-dependencies]
 ipnetwork = "0.16"

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -3,6 +3,7 @@ use libc;
 use nftnl_sys::{self as sys, libc::c_char};
 
 /// A meta expression refers to meta data associated with a packet.
+#[non_exhaustive]
 pub enum Meta {
     /// Packet ethertype protocol (skb->protocol), invalid in OUTPUT.
     Protocol,

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -68,6 +68,7 @@ impl Expression for Payload {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum LLHeaderField {
     Daddr,
     Saddr,
@@ -119,6 +120,7 @@ impl HeaderField for NetworkHeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Ipv4HeaderField {
     Ttl,
     Protocol,
@@ -149,6 +151,7 @@ impl HeaderField for Ipv4HeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Ipv6HeaderField {
     NextHeader,
     HopLimit,
@@ -179,6 +182,7 @@ impl HeaderField for Ipv6HeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum TransportHeaderField {
     Tcp(TcpHeaderField),
     Udp(UdpHeaderField),
@@ -206,6 +210,7 @@ impl HeaderField for TransportHeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum TcpHeaderField {
     Sport,
     Dport,
@@ -230,6 +235,7 @@ impl HeaderField for TcpHeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum UdpHeaderField {
     Sport,
     Dport,
@@ -257,6 +263,7 @@ impl HeaderField for UdpHeaderField {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Icmpv6HeaderField {
     Type,
     Code,


### PR DESCRIPTION
`nftnl` just has a small subset of what `libnftnl` supports. Many of the expressions that can go into rules only cover a few of all the possible things an expression can check. And if you add variants to enums it's techincally a breaking change. So in order to not have to deal with this every time, either breaking how versioning is supposed to be done, or making maaany breaking changes, I mark most of the enums that I think will get extended as `#[non_exhaustive]`.

I also bump the version number as I prepare to release now. And this time I treat it as breaking since `#[non_exhaustive]` was not in place in `0.4.0` :shrug:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/34)
<!-- Reviewable:end -->
