### PR TITLE
Bump libc dependency to the *actual* lowest required

### DIFF
--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -21,7 +21,7 @@ nftnl-1-1-2 = ["nftnl-1-1-1"]
 
 [dependencies]
 cfg-if = "0.1.7"
-libc = "0.2.40"
+libc = "0.2.43"
 
 [build-dependencies]
 cfg-if = "0.1.7"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -21,7 +21,6 @@ nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 [dependencies]
 bitflags = "1.0"
 err-derive = "0.2.4"
-libc = "0.2.40"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.5" }
 

--- a/nftnl/examples/add-rules.rs
+++ b/nftnl/examples/add-rules.rs
@@ -37,13 +37,12 @@
 //! ```
 
 use ipnetwork::{IpNetwork, Ipv4Network};
-use nftnl::{nft_expr, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
+use nftnl::{nft_expr, nftnl_sys::libc, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
 use std::{
     ffi::{self, CString},
     io,
     net::Ipv4Addr,
 };
-
 
 const TABLE_NAME: &str = "example-table";
 const OUT_CHAIN_NAME: &str = "chain-for-outgoing-packets";
@@ -80,7 +79,6 @@ fn main() -> Result<(), Error> {
     batch.add(&out_chain, nftnl::MsgType::Add);
     batch.add(&in_chain, nftnl::MsgType::Add);
 
-
     // === ADD RULE ALLOWING ALL TRAFFIC TO THE LOOPBACK DEVICE ===
 
     // Create a new rule object under the input chain.
@@ -106,7 +104,6 @@ fn main() -> Result<(), Error> {
 
     // Add the rule to the batch.
     batch.add(&allow_loopback_in_rule, nftnl::MsgType::Add);
-
 
     // === ADD A RULE ALLOWING (AND COUNTING) ALL PACKETS TO THE 10.1.0.0/24 NETWORK ===
 
@@ -145,7 +142,6 @@ fn main() -> Result<(), Error> {
     // and all the work on `block_out_to_private_net_rule` so far would go to waste.
     batch.add(&block_out_to_private_net_rule, nftnl::MsgType::Add);
 
-
     // === ADD A RULE ALLOWING ALL OUTGOING ICMPv6 PACKETS WITH TYPE 133 AND CODE 0 ===
 
     let mut allow_router_solicitation = Rule::new(&out_chain);
@@ -168,7 +164,6 @@ fn main() -> Result<(), Error> {
     allow_router_solicitation.add_expr(&nft_expr!(verdict accept));
 
     batch.add(&allow_router_solicitation, nftnl::MsgType::Add);
-
 
     // === FINALIZE THE TRANSACTION AND SEND THE DATA TO NETFILTER ===
 
@@ -223,7 +218,6 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
         Ok(None)
     }
 }
-
 
 #[derive(Debug)]
 struct Error(String);

--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -22,9 +22,8 @@
 //! # nft delete table inet example-filter-ethernet
 //! ```
 
-use nftnl::{nft_expr, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
+use nftnl::{nft_expr, nftnl_sys::libc, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
 use std::{ffi::CString, io};
-
 
 const TABLE_NAME: &str = "example-filter-ethernet";
 const OUT_CHAIN_NAME: &str = "chain-for-outgoing-packets";
@@ -43,7 +42,6 @@ fn main() -> Result<(), Error> {
     out_chain.set_policy(nftnl::Policy::Accept);
     batch.add(&out_chain, nftnl::MsgType::Add);
 
-
     // === ADD RULE DROPPING ALL TRAFFIC TO THE MAC ADDRESS IN `BLOCK_THIS_MAC` ===
 
     let mut block_ethernet_rule = Rule::new(&out_chain);
@@ -61,7 +59,6 @@ fn main() -> Result<(), Error> {
     block_ethernet_rule.add_expr(&nft_expr!(verdict drop));
 
     batch.add(&block_ethernet_rule, nftnl::MsgType::Add);
-
 
     // === FOR FUN, ADD A PACKET THAT MATCHES 50% OF ALL PACKETS ===
 
@@ -120,7 +117,6 @@ fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> Result<Option<&'a
         Ok(None)
     }
 }
-
 
 #[derive(Debug)]
 struct Error(String);

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,6 +1,7 @@
 use crate::{MsgType, NlMsg};
-use libc;
-use nftnl_sys::{self as sys, libc::{c_char, c_void}};
+use nftnl_sys::{self as sys, libc};
+use std::ffi::c_void;
+use std::os::raw::c_char;
 use std::ptr;
 
 /// Error while communicating with netlink

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,8 +1,10 @@
 use crate::{MsgType, Table};
-use libc;
-use nftnl_sys::{self as sys, libc::{c_char, c_void}};
-use std::{ffi::CStr, fmt};
-
+use nftnl_sys::{self as sys, libc};
+use std::{
+    ffi::{c_void, CStr},
+    fmt,
+    os::raw::c_char,
+};
 
 pub type Priority = i32;
 
@@ -113,7 +115,7 @@ impl<'a> Chain<'a> {
             sys::nftnl_chain_set_str(
                 self.chain,
                 sys::NFTNL_CHAIN_TYPE as u16,
-                chain_type.as_c_str().as_ptr() as *const c_char
+                chain_type.as_c_str().as_ptr() as *const c_char,
             );
         }
     }
@@ -155,7 +157,7 @@ impl<'a> fmt::Debug for Chain<'a> {
                 0,
             );
         }
-        let s = unsafe { CStr::from_ptr(buffer.as_ptr() as * const c_char) };
+        let s = unsafe { CStr::from_ptr(buffer.as_ptr() as *const c_char) };
         write!(fmt, "{:?}", s)
     }
 }

--- a/nftnl/src/expr/bitwise.rs
+++ b/nftnl/src/expr/bitwise.rs
@@ -1,10 +1,8 @@
 use super::{Expression, Rule};
 use crate::expr::cmp::ToSlice;
-use libc;
-use nftnl_sys::{
-    self as sys,
-    libc::{c_char, c_void},
-};
+use nftnl_sys::{self as sys, libc};
+use std::ffi::c_void;
+use std::os::raw::c_char;
 
 /// Expression for performing bitwise masking and XOR on the data in a register.
 pub struct Bitwise<M: ToSlice, X: ToSlice> {

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -1,13 +1,10 @@
 use super::{Expression, Rule};
-use libc;
-use nftnl_sys::{
-    self as sys,
-    libc::{c_char, c_void},
-};
+use nftnl_sys::{self as sys, libc};
 use std::{
     borrow::Cow,
-    ffi::CString,
+    ffi::{c_void, CString},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    os::raw::c_char,
     slice,
 };
 
@@ -42,7 +39,6 @@ impl CmpOp {
         }
     }
 }
-
 
 /// Comparator expression. Allows comparing the content of the netfilter register with any value.
 pub struct Cmp<T: ToSlice> {
@@ -108,7 +104,6 @@ macro_rules! nft_expr_cmp {
         $crate::expr::Cmp::new(nft_expr_cmp!(@cmp_op $op), $data)
     };
 }
-
 
 /// A type that can be converted into a byte buffer.
 pub trait ToSlice {

--- a/nftnl/src/expr/counter.rs
+++ b/nftnl/src/expr/counter.rs
@@ -1,5 +1,6 @@
 use super::{Expression, Rule};
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys as sys;
+use std::os::raw::c_char;
 
 /// A counter expression adds a counter to the rule that is incremented to count number of packets
 /// and number of bytes for all packets that has matched the rule.

--- a/nftnl/src/expr/ct.rs
+++ b/nftnl/src/expr/ct.rs
@@ -1,6 +1,6 @@
 use super::{Expression, Rule};
-use libc;
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys::{self as sys, libc};
+use std::os::raw::c_char;
 
 bitflags::bitflags! {
     pub struct States: u32 {
@@ -32,9 +32,17 @@ impl Expression for Conntrack {
             let expr = try_alloc!(sys::nftnl_expr_alloc(b"ct\0" as *const _ as *const c_char));
 
             if let Conntrack::Mark { set: true } = self {
-                sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_SREG as u16, libc::NFT_REG_1 as u32);
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_CT_SREG as u16,
+                    libc::NFT_REG_1 as u32,
+                );
             } else {
-                sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_DREG as u16, libc::NFT_REG_1 as u32);
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_CT_DREG as u16,
+                    libc::NFT_REG_1 as u32,
+                );
             }
             sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_CT_KEY as u16, self.raw_key());
 

--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -1,7 +1,8 @@
 use super::{Expression, Rule};
-use libc;
-use nftnl_sys::{self as sys, libc::{c_char, c_void}};
+use nftnl_sys::{self as sys, libc};
+use std::ffi::c_void;
 use std::mem::size_of_val;
+use std::os::raw::c_char;
 
 /// An immediate expression. Used to set immediate data.
 /// Verdicts are handled separately by [Verdict].

--- a/nftnl/src/expr/lookup.rs
+++ b/nftnl/src/expr/lookup.rs
@@ -1,8 +1,8 @@
 use super::{Expression, Rule};
 use crate::set::Set;
-use libc;
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys::{self as sys, libc};
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 pub struct Lookup {
     set_name: CString,

--- a/nftnl/src/expr/masquerade.rs
+++ b/nftnl/src/expr/masquerade.rs
@@ -1,5 +1,6 @@
 use super::{Expression, Rule};
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys as sys;
+use std::os::raw::c_char;
 
 /// Sets the source IP to that of the output interface.
 pub struct Masquerade;

--- a/nftnl/src/expr/meta.rs
+++ b/nftnl/src/expr/meta.rs
@@ -1,6 +1,6 @@
 use super::{Expression, Rule};
-use libc;
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys::{self as sys, libc};
+use std::os::raw::c_char;
 
 /// A meta expression refers to meta data associated with a packet.
 #[non_exhaustive]

--- a/nftnl/src/expr/payload.rs
+++ b/nftnl/src/expr/payload.rs
@@ -1,6 +1,6 @@
 use super::{Expression, Rule};
-use libc;
-use nftnl_sys::{self as sys, libc::c_char};
+use nftnl_sys::{self as sys, libc};
+use std::os::raw::c_char;
 
 trait HeaderField {
     fn offset(&self) -> u32;
@@ -14,7 +14,6 @@ pub enum Payload {
     Network(NetworkHeaderField),
     Transport(TransportHeaderField),
 }
-
 
 impl Payload {
     fn base(self) -> u32 {

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -37,9 +37,9 @@
 #[macro_use]
 extern crate log;
 
-
 pub use nftnl_sys;
-use nftnl_sys::libc::c_void;
+use nftnl_sys::libc;
+use std::ffi::c_void;
 
 macro_rules! try_alloc {
     ($e:expr) => {{

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -1,6 +1,7 @@
 use crate::{chain::Chain, expr::Expression, MsgType};
-use libc;
-use nftnl_sys::{self as sys, libc::{c_char, c_void}};
+use nftnl_sys::{self as sys, libc};
+use std::ffi::c_void;
+use std::os::raw::c_char;
 
 /// A nftables firewall rule.
 pub struct Rule<'a> {

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -1,13 +1,12 @@
 use crate::{table::Table, MsgType, ProtoFamily};
-use libc;
-use nftnl_sys::{self as sys, libc::{c_char, c_void}};
+use nftnl_sys::{self as sys, libc};
 use std::{
     cell::Cell,
-    ffi::CStr,
+    ffi::{c_void, CStr},
     net::{Ipv4Addr, Ipv6Addr},
+    os::raw::c_char,
     rc::Rc,
 };
-
 
 #[macro_export]
 macro_rules! nft_set {

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -1,13 +1,10 @@
 use crate::{MsgType, ProtoFamily};
-use nftnl_sys::{
-    self as sys,
-    libc::{self, c_char, c_void},
-};
+use nftnl_sys::{self as sys, libc};
 use std::{
     collections::HashSet,
-    ffi::{CStr, CString},
+    ffi::{c_void, CStr, CString},
+    os::raw::c_char,
 };
-
 
 /// Abstraction of `nftnl_table`. The top level container in netfilter. A table has a protocol
 /// family and contain [`Chain`]s that in turn hold the rules.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,11 +1,4 @@
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
 use_field_init_shorthand = true
-condense_wildcard_suffixes = true
-normalize_comments = true
-wrap_comments = true
-merge_imports = true
 
-# Heavily subjective style choices
-comment_width = 100
-blank_lines_upper_bound = 2


### PR DESCRIPTION
I tried changing the libc dependency to an exact version (`=0.2.40`) and it failed to build. So we had specified a too low bound. Now it's bumped to the lowest we actually compile with.

To not need to depend on libc twice I just use the one re-exported from the sys crate. Makes it much more clean.

I also update to get `c_void` and `c_char` from the standard library. Since they have been there for quite a while and that is better than relying on a separate libc one. They are effectively the same, but if something is in the standard library that feels more stable.

I also accidentally formatted the code with my stable formatter and was too lazy to revert it. The more crates we can move over to the stable formatter the better IMO also. So I went ahead and removed all unstable formatting options and just went with it.. Like we did on `system-configuration-rs` very recently as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/35)
<!-- Reviewable:end -->
