### PR TITLE
Add Nat expressions

### DIFF
--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -1,5 +1,5 @@
-use super::{Expression, Rule};
-use nftnl_sys::{self as sys, libc};
+use super::{Expression, Register, Rule};
+use nftnl_sys as sys;
 use std::ffi::c_void;
 use std::mem::size_of_val;
 use std::os::raw::c_char;
@@ -9,6 +9,13 @@ use std::os::raw::c_char;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Immediate<T> {
     pub data: T,
+    pub register: Register,
+}
+
+impl<T> Immediate<T> {
+    pub fn new(data: T, register: Register) -> Self {
+        Self { data, register }
+    }
 }
 
 impl<T> Expression for Immediate<T> {
@@ -21,7 +28,7 @@ impl<T> Expression for Immediate<T> {
             sys::nftnl_expr_set_u32(
                 expr,
                 sys::NFTNL_EXPR_IMM_DREG as u16,
-                libc::NFT_REG_1 as u32,
+                self.register.to_raw(),
             );
 
             sys::nftnl_expr_set(
@@ -39,6 +46,9 @@ impl<T> Expression for Immediate<T> {
 #[macro_export]
 macro_rules! nft_expr_immediate {
     (data $value:expr) => {
-        $crate::expr::Immediate { data: $value }
+        $crate::expr::Immediate {
+            data: $value,
+            register: Register::Reg1,
+        }
     };
 }

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -4,13 +4,30 @@
 //! [`Rule`]: struct.Rule.html
 
 use super::rule::Rule;
-use nftnl_sys as sys;
+use nftnl_sys::{self as sys, libc};
 
 /// Trait for every safe wrapper of an nftables expression.
 pub trait Expression {
     /// Allocates and returns the low level `nftnl_expr` representation of this expression.
     /// The caller to this method is responsible for freeing the expression.
     fn to_expr(&self, rule: &Rule) -> *mut sys::nftnl_expr;
+}
+
+/// A netfilter data register. The expressions store and read data to and from these
+/// when evaluating rule statements.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(i32)]
+pub enum Register {
+    Reg1 = libc::NFT_REG_1,
+    Reg2 = libc::NFT_REG_2,
+    Reg3 = libc::NFT_REG_3,
+    Reg4 = libc::NFT_REG_4,
+}
+
+impl Register {
+    pub fn to_raw(self) -> u32 {
+        self as u32
+    }
 }
 
 mod bitwise;

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -54,6 +54,9 @@ pub use self::masquerade::*;
 mod meta;
 pub use self::meta::*;
 
+mod nat;
+pub use self::nat::*;
+
 mod payload;
 pub use self::payload::*;
 

--- a/nftnl/src/expr/nat.rs
+++ b/nftnl/src/expr/nat.rs
@@ -17,8 +17,8 @@ pub enum NatType {
 pub struct Nat {
     pub nat_type: NatType,
     pub family: ProtoFamily,
-    pub ip_reg: Register,
-    pub port_reg: Option<Register>,
+    pub ip_register: Register,
+    pub port_register: Option<Register>,
 }
 
 impl Expression for Nat {
@@ -32,13 +32,13 @@ impl Expression for Nat {
             sys::nftnl_expr_set_u32(
                 expr,
                 sys::NFTNL_EXPR_NAT_REG_ADDR_MIN as u16,
-                self.ip_reg.to_raw(),
+                self.ip_register.to_raw(),
             );
-            if let Some(port_reg) = self.port_reg {
+            if let Some(port_register) = self.port_register {
                 sys::nftnl_expr_set_u32(
                     expr,
                     sys::NFTNL_EXPR_NAT_REG_PROTO_MIN as u16,
-                    port_reg.to_raw(),
+                    port_register.to_raw(),
                 );
             }
         }

--- a/nftnl/src/expr/nat.rs
+++ b/nftnl/src/expr/nat.rs
@@ -1,0 +1,48 @@
+use super::{Expression, Register, Rule};
+use crate::ProtoFamily;
+use nftnl_sys::{self as sys, libc};
+use std::os::raw::c_char;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(i32)]
+pub enum NatType {
+    /// Source NAT. Changes the source address of a packet
+    SNat = libc::NFT_NAT_SNAT,
+    /// Destination NAT. Changeth the destination address of a packet
+    DNat = libc::NFT_NAT_DNAT,
+}
+
+/// A source or destination NAT statement. Modifies the source or destination address
+/// (and possibly port) of packets.
+pub struct Nat {
+    pub nat_type: NatType,
+    pub family: ProtoFamily,
+    pub ip_reg: Register,
+    pub port_reg: Option<Register>,
+}
+
+impl Expression for Nat {
+    fn to_expr(&self, _rule: &Rule) -> *mut sys::nftnl_expr {
+        let expr =
+            try_alloc!(unsafe { sys::nftnl_expr_alloc(b"nat\0" as *const _ as *const c_char) });
+
+        unsafe {
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_NAT_TYPE as u16, self.nat_type as u32);
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_NAT_FAMILY as u16, self.family as u32);
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_NAT_REG_ADDR_MIN as u16,
+                self.ip_reg.to_raw(),
+            );
+            if let Some(port_reg) = self.port_reg {
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_NAT_REG_PROTO_MIN as u16,
+                    port_reg.to_raw(),
+                );
+            }
+        }
+
+        expr
+    }
+}


### PR DESCRIPTION
This PR is for a personal toy project of mine. So we don't need this change at Mullvad really. Just want to make that clear :+1: 

This library has no support for source and destination NATing yet. This can be very useful for port forwarding etc. So this PR adds the `Nat` expression type. However! This finally hit the limitations of this library. All expressions we have that store data to a netfilter register have always been hardcoded to use `NFT_REG_1` and all expressions/statements reading from registers have been hardcoded to use the same. This worked fine as long as each data consuming expression only had to read a single value. This is not true for nat expressions which can read up to four registers. There are the `NFTNL_EXPR_NAT_REG_ADDR_MIN`, `NFTNL_EXPR_NAT_REG_ADDR_MAX`, `NFTNL_EXPR_NAT_REG_PROTO_MIN` and `NFTNL_EXPR_NAT_REG_PROTO_MAX` values to set on the nat expression. I currently don't care about supporting ranges of IPs or ports. So I skip the `_MAX` variant. Only setting the `_MIN` variants means it's not a range.

I honestly don't know exactly what the ranges are for. But I guess it's for load balancing. There is very little documentation on this entire library sadly. The man page for `nft` nor the nftables wiki mentions the ranges except that it's a valid syntax to input :shrug: 

Anyway. In order to fix the problem of having an expression that reads from multiple registers, I changed the `Immediate` expression to also take a `Register` enum that controls which register it writes to. This is fine for now. This is of course a breaking change. But I made the macro kind of hide this for now as a workaround. So anyone using the macro won't notice the difference.

## Examples

This is how one can create a port forwarding rule now:
```rust
        let public_port = 1234u16;
        let ip_to_forward_to = Ipv4Addr::new(10, 0, 100, 200);
        let port_to_forward_to = 4321u16;

        let mut rule = Rule::new(&prerouting_chain);

        rule.add_expr(&nft_expr!(meta l4proto));
        rule.add_expr(&nft_expr!(cmp == libc::IPPROTO_TCP as u8));

        rule.add_expr(&nft_expr!(payload tcp dport));
        rule.add_expr(&nft_expr!(cmp == public_port.to_be()));

        rule.add_expr(&Immediate::new(ip_to_forward_to, expr::Register::Reg1));
        rule.add_expr(&Immediate::new(port_to_forward_to.to_be(), expr::Register::Reg2));
        let nat_expr = expr::Nat {
            nat_type: expr::NatType::DNat,
            family: ProtoFamily::Ipv4,
            ip_reg: expr::Register::Reg1,
            port_reg: Some(expr::Register::Reg2),
        };
        rule.add_expr(&nat_expr);
```
It results in a rule like this:
```
tcp dport 1234 dnat to 10.0.100.200:4321
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/36)
<!-- Reviewable:end -->
