### PR TITLE
Make Batch,Iter,Table,Rule&Chain implement Send+Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Added
+- Implement Send+Sync for Table, Chain, Rule, Batch and Iter (batch iterator)
 
 
 ## [0.5.0] - 2020-06-04

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -25,6 +25,11 @@ pub struct Batch {
     seq: u32,
 }
 
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads
+unsafe impl Send for Batch {}
+unsafe impl Sync for Batch {}
+
 impl Batch {
     /// Creates a new nftnl batch with the [default page size].
     ///
@@ -152,6 +157,11 @@ pub struct Iter<'a> {
     iovecs: ::std::vec::IntoIter<libc::iovec>,
     _marker: ::std::marker::PhantomData<&'a ()>,
 }
+
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads.
+unsafe impl<'a> Send for Iter<'a> {}
+unsafe impl<'a> Sync for Iter<'a> {}
 
 impl<'a> Iterator for Iter<'a> {
     type Item = &'a [u8];

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -72,6 +72,11 @@ pub struct Chain<'a> {
     table: &'a Table,
 }
 
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads
+unsafe impl<'a> Send for Chain<'a> {}
+unsafe impl<'a> Sync for Chain<'a> {}
+
 impl<'a> Chain<'a> {
     /// Creates a new chain instance inside the given [`Table`] and with the given name.
     ///

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -9,6 +9,11 @@ pub struct Rule<'a> {
     chain: &'a Chain<'a>,
 }
 
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads
+unsafe impl<'a> Send for Rule<'a> {}
+unsafe impl<'a> Sync for Rule<'a> {}
+
 impl<'a> Rule<'a> {
     /// Creates a new rule object in the given [`Chain`].
     ///

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -15,6 +15,11 @@ pub struct Table {
     family: ProtoFamily,
 }
 
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads
+unsafe impl Send for Table {}
+unsafe impl Sync for Table {}
+
 impl Table {
     /// Creates a new table instance with the given name and protocol family.
     pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Table {


### PR DESCRIPTION
Implementing `Send` for a type allows it to transition in owned form between threads. Only one thread can own it and use it at any given time. Implementing `Sync` means immutable references to the instance are allowed to transition between threads. This means there can be multiple immutable references to the same instance alive at the same time in multiple threads. But since they are immutable borrows all threads can only "read" from the instance, or call `&self` methods.

A lot of the types in `nftnl` contain raw pointers of types from the underlying `-sys` crate. So by definition Rust is conservative here and assume the types are not `Send` nor `Sync` for safety. It's up to the implementor to prove those traits hold and unsafely implement them.

I have not proven in any way if these types are safe to access (immutably) from multiple threads at once, but I can't imagine why they would not be. All methods that modify the memory should be taking `&mut self` anyway and can as a result not be called in parallel and screw things up anyway. For the same reason `Vec` from the standard library implements both these traits. But I could be wrong of course.

The reason for this PR is that I'm trying to use `nftnl` in an async context in a private project. And requirements on futures are usually that they are `Send + Sync` so they can be moved between worker threads between yield points etc. As a result, this library is not really usable without implementing these traits for most types that are used when modifying the firewall.

I thought this could be usable at Mullvad as well since we move more and more stuff to async, and eventually we might want to do it with the firewall as well?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/37)
<!-- Reviewable:end -->
