### PR TITLE
Upgrade cfg-if dependency to 1.0

### DIFF
--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -20,9 +20,9 @@ nftnl-1-1-1 = ["nftnl-1-1-0"]
 nftnl-1-1-2 = ["nftnl-1-1-1"]
 
 [dependencies]
-cfg-if = "0.1.7"
+cfg-if = "1.0"
 libc = "0.2.43"
 
 [build-dependencies]
-cfg-if = "0.1.7"
+cfg-if = "1.0"
 pkg-config = "0.3"


### PR DESCRIPTION
I just happened to stumble on the fact that `cfg-if` came out with version `1.0.0.` just hours ago. It's a pretty small crate and rather simple macro. So I guess this means they have decided on the final shape and form of that macro. Which is good. Probably means we virtually never have to upgrade it again :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/38)
<!-- Reviewable:end -->
