### PR TITLE
Stop memory leak in get_tables_cb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Register` enum and a register field to the `Immediate` expression. Allowing control
   over which netfilter register the immediate data is loaded into
 
+### Fixed
+- Fix memory leak in `table::get_tables_cb`.
+
 
 ## [0.5.0] - 2020-06-04
 ### Added

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -94,6 +94,7 @@ pub fn get_tables_cb(header: &libc::nlmsghdr, tables: &mut HashSet<CString>) -> 
         let err = sys::nftnl_table_nlmsg_parse(header, nf_table);
         if err < 0 {
             error!("Failed to parse nelink table message - {}", err);
+            sys::nftnl_table_free(nf_table);
             return err;
         }
         let table_name = CStr::from_ptr(sys::nftnl_table_get_str(
@@ -102,6 +103,7 @@ pub fn get_tables_cb(header: &libc::nlmsghdr, tables: &mut HashSet<CString>) -> 
         ))
         .to_owned();
         tables.insert(table_name);
+        sys::nftnl_table_free(nf_table);
     };
     return 1;
 }


### PR DESCRIPTION
A small fix to not leak memory in `get_tables_cb()`. Don't worry about introducing the bug however, this is all my fault - I managed to introduce it almost 2 years ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/39)
<!-- Reviewable:end -->
