### PR TITLE
Use fully qualified type for Register

### DIFF
--- a/nftnl/src/expr/immediate.rs
+++ b/nftnl/src/expr/immediate.rs
@@ -48,7 +48,7 @@ macro_rules! nft_expr_immediate {
     (data $value:expr) => {
         $crate::expr::Immediate {
             data: $value,
-            register: Register::Reg1,
+            register: $crate::expr::Register::Reg1,
         }
     };
 }


### PR DESCRIPTION
The `nft_expr_immediate` was not using a fully qualified path for the `Register` type, forcing users to import it at call site. I changed it to be fully qualified so that it doesn't depend on the call site now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/40)
<!-- Reviewable:end -->
