### PR TITLE
fixes #45 - Add a log expression with group argument

### DIFF
--- a/nftnl/src/expr/log.rs
+++ b/nftnl/src/expr/log.rs
@@ -6,10 +6,32 @@ use nftnl_sys::{
 
 /// A log expression.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Log {}
+pub enum Log {
+    NoGroup,
+    Group(LogGroup),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum LogGroup {
+    LogGroupZero,
+    LogGroupOne,
+    LogGroupTwo,
+    LogGroupThree,
+    LogGroupFour,
+    LogGroupFive,
+    LogGroupSix,
+    LogGroupSeven,
+}
 
 
-impl Log {}
+impl Log {
+    pub fn new() -> Self {
+        Log::NoGroup
+    }
+    pub fn new_with_group(group: LogGroup) -> Self {
+        Log::Group(group)
+    }
+}
 
 impl Expression for Log {
     fn to_expr(&self, _rule: &Rule) -> *mut sys::nftnl_expr {
@@ -17,7 +39,16 @@ impl Expression for Log {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"log\0" as *const _ as *const c_char
             ));
-
+            match self {
+                Log::NoGroup => (),
+                Log::Group(group) => {
+                    sys::nftnl_expr_set_u32(
+                        expr,
+                        sys::NFTNL_EXPR_LOG_GROUP as u16,
+                        *group as u32,
+                    );
+                }
+            }
             expr
         }
     }
@@ -25,7 +56,10 @@ impl Expression for Log {
 
 #[macro_export]
 macro_rules! nft_expr_log {
+    (group $group:ident) => {
+        $crate::expr::Log::new_with_group($group)
+    };
     () => {
-        $crate::expr::Log {}
+        $crate::expr::Log::new()
     };
 }

--- a/nftnl/src/expr/log.rs
+++ b/nftnl/src/expr/log.rs
@@ -1,0 +1,31 @@
+use super::{Expression, Rule};
+use nftnl_sys::{
+    self as sys,
+    libc::c_char,
+};
+
+/// A log expression.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Log {}
+
+
+impl Log {}
+
+impl Expression for Log {
+    fn to_expr(&self, _rule: &Rule) -> *mut sys::nftnl_expr {
+        unsafe {
+            let expr = try_alloc!(sys::nftnl_expr_alloc(
+                b"log\0" as *const _ as *const c_char
+            ));
+
+            expr
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_log {
+    () => {
+        $crate::expr::Log {}
+    };
+}

--- a/nftnl/src/expr/log.rs
+++ b/nftnl/src/expr/log.rs
@@ -5,10 +5,8 @@ use nftnl_sys::{
 };
 
 /// A log expression.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum Log {
-    NoGroup,
-    Group(LogGroup),
+pub struct Log {
+    group: Option<LogGroup>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -25,11 +23,8 @@ pub enum LogGroup {
 
 
 impl Log {
-    pub fn new() -> Self {
-        Log::NoGroup
-    }
-    pub fn new_with_group(group: LogGroup) -> Self {
-        Log::Group(group)
+    pub fn new(group: Option<LogGroup>) -> Self {
+        Log { group }
     }
 }
 
@@ -39,16 +34,13 @@ impl Expression for Log {
             let expr = try_alloc!(sys::nftnl_expr_alloc(
                 b"log\0" as *const _ as *const c_char
             ));
-            match self {
-                Log::NoGroup => (),
-                Log::Group(group) => {
-                    sys::nftnl_expr_set_u32(
-                        expr,
-                        sys::NFTNL_EXPR_LOG_GROUP as u16,
-                        *group as u32,
-                    );
-                }
-            }
+            if let Some(group) = self.group {
+                sys::nftnl_expr_set_u32(
+                    expr,
+                    sys::NFTNL_EXPR_LOG_GROUP as u16,
+                    group as u32,
+                );
+            };
             expr
         }
     }
@@ -57,9 +49,9 @@ impl Expression for Log {
 #[macro_export]
 macro_rules! nft_expr_log {
     (group $group:ident) => {
-        $crate::expr::Log::new_with_group($group)
+        $crate::expr::Log::new($group)
     };
     () => {
-        $crate::expr::Log::new()
+        $crate::expr::Log::new(None)
     };
 }

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -74,6 +74,9 @@ macro_rules! nft_expr {
     (cmp $op:tt $data:expr) => {
         nft_expr_cmp!($op $data)
     };
+    (log group $group:ident) => {
+        nft_expr_log!(group $group)
+    };
     (log) => {
         nft_expr_log!()
     };

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -60,6 +60,9 @@ pub use self::nat::*;
 mod payload;
 pub use self::payload::*;
 
+mod log;
+pub use self::log::*;
+
 mod verdict;
 pub use self::verdict::*;
 
@@ -70,6 +73,9 @@ macro_rules! nft_expr {
     };
     (cmp $op:tt $data:expr) => {
         nft_expr_cmp!($op $data)
+    };
+    (log) => {
+        nft_expr_log!()
     };
     (counter) => {
         $crate::expr::Counter


### PR DESCRIPTION
This PR adds a `log` expression, solving #45 . To add a log rule do

```rust
use std::ffi::CString;
use nftnl::{Rule, Chain, nft_expr};
let chain = Chain::new(&CString::new("some-chain-name")?);
let rule = Rule::new(&chain);
rule.add_expr(&nft_expr!(log));
```
And then insert in the chain where you bet useful.

To set the `group` argument to a value between zero and seven, pick a value in the `expr::LogGroup` enum and do :
```rust
use std::ffi::CString;
use nftnl::{Rule, Chain, nft_expr, expr::LogGroup::LogGroupZero};
let chain = Chain::new(&CString::new("some-chain-name")?);
let rule = Rule::new(&chain);
rule.add_expr(&nft_expr!(log group LogGroupZero));
```
As stated in [nftables' wiki](https://wiki.nftables.org/wiki-nftables/index.php/Logging_traffic), setting the `group` argument activates NFLog output, useable by ulogd2, a more advanced logging target than the default. The default is to output to kernel log, which is a pity, because it's often unprotected. ulogd needs a running daemon, and lets you choose output targets and log format.


So this PR is probably not the most urgent thing in Mullvad userland, but can prove useful, and is very compact. Besides, it _is_ very much needed for other applications that would use this library for its quality. `nftnl-rs` rocks, by the way ! :1st_place_medal:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/46)
<!-- Reviewable:end -->
