### PR TITLE
Update libc dependency to 0.2.107

### DIFF
--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -21,7 +21,7 @@ nftnl-1-1-2 = ["nftnl-1-1-1"]
 
 [dependencies]
 cfg-if = "1.0"
-libc = "0.2.43"
+libc = "0.2.107"
 
 [build-dependencies]
 cfg-if = "1.0"


### PR DESCRIPTION
This PR updates the libc crate dependency to the most recently released version.

Compared to the version that was used previously (0.2.43), the new version contains the changes made in rust-lang/libc#2152 (and released in libc version 0.2.95), which allows nftnl-rs to be used on Linux systems running musl-libc instead of glibc.

For nftnl-rs to work on musl-libc systems, the libc dependency in mullvad/mnl-rs has to be updated as well. I have opened a PR in the mnl-rs repository to do so: mullvad/mnl-rs#11. The version of mnl-rs used in this repository should probably be updated accordingly before merging this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/48)
<!-- Reviewable:end -->
