### PR TITLE
Fix minimal versions (cargo +nightly update -Z minimal-versions)

### DIFF
--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -25,4 +25,4 @@ libc = "0.2.43"
 
 [build-dependencies]
 cfg-if = "1.0"
-pkg-config = "0.3"
+pkg-config = "0.3.19"

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -21,7 +21,7 @@ nftnl-1-1-2 = ["nftnl-1-1-1"]
 
 [dependencies]
 cfg-if = "1.0"
-libc = "0.2.43"
+libc = "0.2.44"
 
 [build-dependencies]
 cfg-if = "1.0"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -20,7 +20,7 @@ nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 
 [dependencies]
 bitflags = "1.0.4"
-err-derive = "0.3.0"
+err-derive = "0.3.1"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.6" }
 

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -19,7 +19,7 @@ nftnl-1-1-1 = ["nftnl-sys/nftnl-1-1-1"]
 nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.0.4"
 err-derive = "0.3.0"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.6" }


### PR DESCRIPTION
Similar to https://github.com/mullvad/mnl-rs/pull/12

I had to first fix `err-derive` upstream (https://gitlab.com/torkleyy/err-derive/-/issues/18), but then we could bump all our dependencies to make this crate actually build with all dependencies lowered to their lowest possible versions.

Each commit message explains a little bit about that specific bump

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/50)
<!-- Reviewable:end -->
