### PR TITLE
removes expect statments from nft_set macro

### DIFF
--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -17,9 +17,9 @@ macro_rules! nft_set {
         nft_set!($name, $id, $table, $family)
     };
     ($name:expr, $id:expr, $table:expr, $family:expr; [ $($value:expr,)* ]) => {{
-        let mut set = nft_set!($name, $id, $table, $family).expect("Set allocation failed");
+        let mut set = nft_set!($name, $id, $table, $family);
         $(
-            set.add($value).expect(stringify!(Unable to add $value to set $name));
+            set.add($value);
         )*
         set
     }};


### PR DESCRIPTION
This commit removes expect statements from the nft_set macro which cause compile errors since the Result was remove in #21 

small repro:

```rust
use nftnl::{nft_set, set::Set, Table, ProtoFamily};
use std::ffi::CString;

fn main() {
   let t = Table::new(&CString::new("test").unwrap(), nftnl::ProtoFamily::Ipv4);
   let s:Set<std::net::Ipv4Addr> = nft_set!(&CString::new("s1").unwrap(), 0, &t, ProtoFamily::Ipv4; [ &[1,1,1,1].into(), ]);
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/54)
<!-- Reviewable:end -->
