### PR TITLE
Miscelaneous fixes and features: Set bugfixes, Conntrack zone support, FIB support

### DIFF
--- a/nftnl/src/expr/fib.rs
+++ b/nftnl/src/expr/fib.rs
@@ -1,0 +1,121 @@
+use super::{Expression, Rule};
+use nftnl_sys::{self as sys, libc};
+use std::os::raw::c_char;
+use std::str::FromStr;
+
+#[non_exhaustive]
+pub enum FibResult {
+    Oif,
+    OifName,
+    AddrType,
+}
+
+impl FromStr for FibResult {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "oif" => Ok(FibResult::Oif),
+            "oifname" => Ok(FibResult::OifName),
+            "type" => Ok(FibResult::AddrType),
+            _ => Err("Invalid FibResult variant"),
+        }
+    }
+}
+
+impl FibResult {
+    pub fn raw_result_type(&self) -> u32 {
+        use FibResult::*;
+
+        // From: linux/netfilter/nf_tables.h
+        match *self {
+            Oif => 1,
+            OifName => 2,
+            AddrType => 3,
+        }
+    }
+}
+
+#[non_exhaustive]
+pub enum Fib {
+    SAddr { result: &'static str },
+    DAddr { result: &'static str },
+    Mark { result: &'static str },
+    Iif { result: &'static str },
+    Oif { result: &'static str },
+    Present { result: &'static str },
+}
+
+impl Fib {
+    pub fn flags(&self) -> u32 {
+        use Fib::*;
+
+        // From: linux/netfilter/nf_tables.h
+        match *self {
+            SAddr { .. } => 1 << 0,
+            DAddr { .. } => 1 << 1,
+            Mark { .. } => 1 << 2,
+            Iif { .. } => 1 << 3,
+            Oif { .. } => 1 << 4,
+            Present { .. } => 1 << 5,
+        }
+    }
+
+    pub fn result(&self) -> u32 {
+        use Fib::*;
+
+        let result: FibResult = match self {
+            SAddr { result }
+            | DAddr { result }
+            | Mark { result }
+            | Iif { result }
+            | Oif { result }
+            | Present { result } => result
+                .parse()
+                .expect("Unexpected fib result. Must be type, oif or oifname."),
+        };
+
+        result.raw_result_type()
+    }
+}
+
+impl Expression for Fib {
+    fn to_expr(&self, _rule: &Rule) -> *mut sys::nftnl_expr {
+        unsafe {
+            let expr = try_alloc!(sys::nftnl_expr_alloc(b"fib\0" as *const _ as *const c_char));
+
+            sys::nftnl_expr_set_u32(
+                expr,
+                sys::NFTNL_EXPR_FIB_DREG as u16,
+                libc::NFT_REG_1 as u32,
+            );
+
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_FIB_RESULT as u16, self.result());
+            sys::nftnl_expr_set_u32(expr, sys::NFTNL_EXPR_FIB_FLAGS as u16, self.flags());
+
+            expr
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! nft_expr_fib {
+    (saddr $result:expr) => {
+        $crate::expr::Fib::SAddr { result: $result }
+    };
+    (daddr $result:expr) => {
+        $crate::expr::Fib::DAddr { result: $result }
+    };
+    (mark $result:expr) => {
+        $crate::expr::Fib::Mark { result: $result }
+    };
+    (iif $result:expr) => {
+        $crate::expr::Fib::Iif { result: $result }
+    };
+    (oif $result:expr) => {
+        $crate::expr::Fib::Oif { result: $result }
+    };
+    (present $result:expr) => {
+        $crate::expr::Fib::Present { result: $result }
+    };
+}

--- a/nftnl/src/expr/mod.rs
+++ b/nftnl/src/expr/mod.rs
@@ -63,6 +63,9 @@ pub use self::payload::*;
 mod verdict;
 pub use self::verdict::*;
 
+mod fib;
+pub use self::fib::*;
+
 #[macro_export(local_inner_macros)]
 macro_rules! nft_expr {
     (bitwise mask $mask:expr,xor $xor:expr) => {
@@ -103,5 +106,8 @@ macro_rules! nft_expr {
     };
     (immediate $expr:ident $value:expr) => {
         nft_expr_immediate!($expr $value)
+    };
+    (fib $expr:ident $result:expr) => {
+        nft_expr_fib!($expr $result)
     };
 }

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -32,6 +32,11 @@ pub struct Set<'a, K> {
     _marker: ::std::marker::PhantomData<K>,
 }
 
+// Safety: It should be safe to pass this around and
+// *read* from it from multiple threads
+unsafe impl<'a, K> Send for Set<'a, K> where K: Send + Sync {}
+unsafe impl<'a, K> Sync for Set<'a, K> where K: Send + Sync {}
+
 impl<'a, K> Set<'a, K> {
     pub fn new(name: &CStr, id: u32, table: &'a Table, family: ProtoFamily) -> Self
     where

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -17,9 +17,9 @@ macro_rules! nft_set {
         nft_set!($name, $id, $table, $family)
     };
     ($name:expr, $id:expr, $table:expr, $family:expr; [ $($value:expr,)* ]) => {{
-        let mut set = nft_set!($name, $id, $table, $family).expect("Set allocation failed");
+        let mut set = nft_set!($name, $id, $table, $family);
         $(
-            set.add($value).expect(stringify!(Unable to add $value to set $name));
+            set.add($value);
         )*
         set
     }};
@@ -45,11 +45,6 @@ impl<'a, K> Set<'a, K> {
             sys::nftnl_set_set_str(set, sys::NFTNL_SET_NAME as u16, name.as_ptr());
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_ID as u16, id);
 
-            sys::nftnl_set_set_u32(
-                set,
-                sys::NFTNL_SET_FLAGS as u16,
-                (libc::NFT_SET_ANONYMOUS | libc::NFT_SET_CONSTANT) as u32,
-            );
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_TYPE as u16, K::TYPE);
             sys::nftnl_set_set_u32(set, sys::NFTNL_SET_KEY_LEN as u16, K::LEN);
 


### PR DESCRIPTION
Folks, as I attempted to rewrite MozVPN Linux netfilter code in Rust I bumped into a few issues that are addressed in this PR.

1. `Set` creation and `nft_set` macro bugs: 50915b66b8455b05beb5291934d67761fe69bbda
2. Conntrack zone support: f14e104e803f95988ee8e57aec8b30c391b89259
3. FIB support: 3b60247ddee8b2363bec5b194a778bfd91f9c003

I also learned about missing definitions on libc, I'll send a PR up there at some point as well. You'll notice I used some hradcoded numbers here and that is the reason. For reference: https://github.com/rust-lang/libc/issues/3566

The MozVPN PR is not up yet, but I'll link to it here once it is. Cheers!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/55)
<!-- Reviewable:end -->
