### PR TITLE
Replace `err_derive` dependency with manual impl of Display + Error

### DIFF
--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -20,7 +20,6 @@ nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 
 [dependencies]
 bitflags = "1.0.4"
-err-derive = "0.3.1"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.6.1" }
 

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,13 +1,21 @@
 use crate::{MsgType, NlMsg};
+use core::fmt;
 use nftnl_sys::{self as sys, libc};
 use std::ffi::c_void;
 use std::os::raw::c_char;
 use std::ptr;
 
 /// Error while communicating with netlink
-#[derive(err_derive::Error, Debug)]
-#[error(display = "Error while communicating with netlink")]
+#[derive(Debug)]
 pub struct NetlinkError(());
+
+impl fmt::Display for NetlinkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "Error while communicating with netlink".fmt(f)
+    }
+}
+
+impl std::error::Error for NetlinkError {}
 
 /// Check if the kernel supports batched netlink messages to netfilter.
 pub fn batch_is_supported() -> std::result::Result<bool, NetlinkError> {


### PR DESCRIPTION
Building this library on beta or nightly yields the following warning:
```
warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
  --> nftnl/src/batch.rs:8:10
   |
8  | #[derive(err_derive::Error, Debug)]
   |          ^----------------
   |          |
   |          `Error` is not local
   |          move the `impl` block outside of this constant `_DERIVE_std_error_Error_FOR_NetlinkError`
9  | #[error(display = "Error while communicating with netlink")]
10 | pub struct NetlinkError(());
   |            ------------ `NetlinkError` is not local
```

We only have a single error in this crate, and it's an extremely simple one. Here I just replace this derive macro with a simple manual implementation! Less weird bugs and much more future proof! And fewer dependencies! :partying_face:  This change removes *eleven* dependencies from the dependency tree of this (should be) small library.

Getting rid of these warnings is a prerequisite for getting #57 into a working state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/59)
<!-- Reviewable:end -->
