### PR TITLE
Upgrade crates to Rust 2021 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Upgrade crates to Rust 2021 edition.
 
 
 ## [0.6.2] - 2022-02-11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["nftnl-sys", "nftnl"]

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mullvad/nftnl-rs"
 readme = "README.md"
 keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "external-ffi-bindings", "no-std"]
-edition = "2018"
+edition = "2021"
 
 
 [features]

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "external-ffi-bindings", "no-std"]
 edition = "2021"
+rust-version = "1.56.0"
 
 
 [features]

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "api-bindings"]
 edition = "2021"
+rust-version = "1.56.0"
 
 [features]
 nftnl-1-0-7 = ["nftnl-sys/nftnl-1-0-7"]

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mullvad/nftnl-rs"
 readme = "../README.md"
 keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "api-bindings"]
-edition = "2018"
+edition = "2021"
 
 [features]
 nftnl-1-0-7 = ["nftnl-sys/nftnl-1-0-7"]


### PR DESCRIPTION
No immediate need for the new edition. But no reason to leave it at 2018. Allows more modern Rust code and can be helpful in certain cases. Uses newer dependency resolver, brings more stuff into the prelude and more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/61)
<!-- Reviewable:end -->
