### PR TITLE
feat: safe creation of a base chain

### DIFF
--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -22,11 +22,11 @@
 //! # nft delete table inet example-filter-ethernet
 //! ```
 
-use nftnl::{nft_expr, nftnl_sys::libc, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table};
-use std::{ffi::CString, io};
+use nftnl::{nft_expr, nftnl_sys::libc, *};
+use std::{ffi::CStr, io};
 
-const TABLE_NAME: &str = "example-filter-ethernet";
-const OUT_CHAIN_NAME: &str = "chain-for-outgoing-packets";
+const TABLE_NAME: &CStr = c"example-filter-ethernet";
+const OUT_CHAIN_NAME: &CStr = c"chain-for-outgoing-packets";
 
 const BLOCK_THIS_MAC: &[u8] = &[0, 0, 0, 0, 0, 0];
 
@@ -34,12 +34,16 @@ fn main() -> io::Result<()> {
     // For verbose explanations of what all these lines up until the rule creation does, see the
     // `add-rules` example.
     let mut batch = Batch::new();
-    let table = Table::new(&CString::new(TABLE_NAME).unwrap(), ProtoFamily::Inet);
+    let table = Table::new(TABLE_NAME, ProtoFamily::Inet);
     batch.add(&table, nftnl::MsgType::Add);
 
-    let mut out_chain = Chain::new(&CString::new(OUT_CHAIN_NAME).unwrap(), &table);
-    out_chain.set_hook(nftnl::Hook::Out, 3);
-    out_chain.set_policy(nftnl::Policy::Accept);
+    let mut out_chain = Chain::new(OUT_CHAIN_NAME, &table);
+    let setter = BaseChainSetter::new()
+        .chain_type(ChainType::Filter)
+        .hook(Hook::Out)
+        .priority(Priority::Integer(3))
+        .policy(Some(Policy::Accept));
+    setter.try_set(&mut out_chain).unwrap();
     batch.add(&out_chain, nftnl::MsgType::Add);
 
     // === ADD RULE DROPPING ALL TRAFFIC TO THE MAC ADDRESS IN `BLOCK_THIS_MAC` ===

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -1,4 +1,4 @@
-use crate::{MsgType, Table};
+use crate::{MsgType, ProtoFamily, Table};
 use nftnl_sys::{self as sys, libc};
 use std::{
     ffi::{c_void, CStr},
@@ -6,7 +6,70 @@ use std::{
     os::raw::c_char,
 };
 
-pub type Priority = i32;
+/// Priority of a chain. This can be an integral value, a named priority, 
+/// or a named priority with an offset.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Priority {
+    Integer(i32),
+    Name(PriorityName),
+    NamedOffset(PriorityName, i32),
+}
+
+/// Named priorities for chains.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum PriorityName {
+    Raw,
+    Mangle,
+    DstNat,
+    Filter,
+    Security,
+    SrcNat,
+    Out,
+}
+
+impl Priority {
+    /// Get the priority value for a given family and hook.
+    /// 
+    /// If the combination is invalid, `None` is returned.
+    pub const fn value(self, family: ProtoFamily, hook: Hook) -> Option<i32> {
+        match self {
+            Priority::Integer(value) => Some(value),
+            Priority::Name(name) => Self::named(name, family, hook),
+            Priority::NamedOffset(name, offset) => {
+                // not using `Option::map` to make it const
+                if let Some(value) = Self::named(name, family, hook) {
+                    value.checked_add(offset)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    const fn named(name: PriorityName, family: ProtoFamily, hook: Hook) -> Option<i32> {
+        use Hook::*;
+        use PriorityName::*;
+        use ProtoFamily::*;
+        // see nft manpage for compatibility matrices
+        match (name, family, hook) {
+            // Table 6
+            (Raw, Inet | Ipv4 | Ipv6, _) => Some(libc::NF_IP_PRI_RAW),
+            (Mangle, Inet | Ipv4 | Ipv6, _) => Some(libc::NF_IP_PRI_MANGLE),
+            (DstNat, Inet | Ipv4 | Ipv6, PreRouting) => Some(libc::NF_IP_PRI_NAT_DST),
+            (Filter, Inet | Ipv4 | Ipv6 | Arp | NetDev, _) => Some(libc::NF_IP_PRI_FILTER),
+            (Security, Inet | Ipv4 | Ipv6, _) => Some(libc::NF_IP_PRI_SECURITY),
+            (SrcNat, Inet | Ipv4 | Ipv6, PostRouting) => Some(libc::NF_IP_PRI_NAT_SRC),
+            // Table 7
+            // Bridge constants not defined in libc yet, see
+            // https://github.com/rust-lang/libc/pull/3734
+            (DstNat, Bridge, PreRouting) => Some(-300),
+            (Filter, Bridge, _) => Some(-200),
+            (PriorityName::Out, Bridge, Hook::Out) => Some(100),
+            (SrcNat, Bridge, PostRouting) => Some(300),
+            _ => None,
+        }
+    }
+}
 
 /// The netfilter event hooks a chain can register for.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -50,38 +113,47 @@ pub enum ChainType {
 }
 
 impl ChainType {
-    fn as_c_str(&self) -> &'static [u8] {
-        match *self {
+    fn as_c_str(&self) -> &'static CStr {
+        let bytes: &[u8] = match *self {
             ChainType::Filter => b"filter\0",
             ChainType::Route => b"route\0",
             ChainType::Nat => b"nat\0",
-        }
+        };
+        unsafe { CStr::from_bytes_with_nul_unchecked(bytes) }
     }
 }
 
-/// Abstraction of a `nftnl_chain`. Chains reside inside [`Table`]s and they hold [`Rule`]s.
+/// Abstraction of a `nftnl_chain`. Chains reside inside [`Tables`](crate::Table) and they hold [`Rules`](crate::Rule).
 ///
-/// There are two types of chains, "base chain" and "regular chain". See [`set_hook`] for more
-/// details.
+/// There are two types of chains, **base chains** and **regular chains**.
 ///
-/// [`Table`]: struct.Table.html
-/// [`Rule`]: struct.Rule.html
-/// [`set_hook`]: #method.set_hook
+/// A regular chain is not an entry point for packets, and
+/// "may be used as jump target and is used for better rule organization".
+///
+/// A base chain on the other hand is hooked into the networking stack and is an entry point for packets.
+/// However, there are certain constraints for it to be valid. Therefore, a base chain may only be
+/// set through the [`BaseChainSetter`] and its [`try_set`](BaseChainSetter::try_set) function.
+///
+/// See the nftables manpage for more information.
 pub struct Chain<'a> {
     chain: *mut sys::nftnl_chain,
     table: &'a Table,
 }
 
-// Safety: It should be safe to pass this around and *read* from it
-// from multiple threads
-unsafe impl<'a> Send for Chain<'a> {}
-unsafe impl<'a> Sync for Chain<'a> {}
-
 impl<'a> Chain<'a> {
-    /// Creates a new chain instance inside the given [`Table`] and with the given name.
+    /// Create a regular chain.
     ///
-    /// [`Table`]: struct.Table.html
-    pub fn new<T: AsRef<CStr>>(name: &T, table: &'a Table) -> Chain<'a> {
+    /// ```
+    /// use nftnl::{Chain, Table, ProtoFamily};
+    /// use std::ffi::CString;
+    ///
+    /// let table_name = CString::new("test-table").unwrap();
+    /// let chain_name = CString::new("test-chain").unwrap();
+    /// let table = Table::new(&table_name, ProtoFamily::Inet);
+    ///
+    /// let chain = Chain::new(&chain_name, &table);
+    /// ```
+    pub fn new<T: AsRef<CStr>>(name: T, table: &'a Table) -> Self {
         unsafe {
             let chain = try_alloc!(sys::nftnl_chain_alloc());
             sys::nftnl_chain_set_u32(
@@ -98,41 +170,186 @@ impl<'a> Chain<'a> {
             Chain { chain, table }
         }
     }
+}
 
-    /// Sets the hook and priority for this chain. Without calling this method the chain well
-    /// become a "regular chain" without any hook and will thus not receive any traffic unless
-    /// some rule forward packets to it via goto or jump verdicts.
-    ///
-    /// By calling `set_hook` with a hook the chain that is created will be registered with that
-    /// hook and is thus a "base chain". A "base chain" is an entry point for packets from the
-    /// networking stack.
-    pub fn set_hook(&mut self, hook: Hook, priority: Priority) {
-        unsafe {
-            sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_HOOKNUM as u16, hook as u32);
-            sys::nftnl_chain_set_s32(self.chain, sys::NFTNL_CHAIN_PRIO as u16, priority);
+/// A setter for configuring a valid base chain.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BaseChainSetter<'a> {
+    chain_type: Option<ChainType>,
+    hook: Option<Hook>,
+    priority: Option<Priority>,
+    device: Option<&'a CStr>,
+    policy: Option<Policy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Errors that can occur when setting a base chain through [`BaseChainSetter::try_set`].
+pub enum BaseChainError {
+    MissingChainType,
+    MissingHook,
+    MissingPriority,
+    InvalidCombination,
+    InvalidPriority,
+}
+
+impl fmt::Display for BaseChainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use BaseChainError::*;
+        match self {
+            MissingChainType => write!(f, "missing chain type"),
+            MissingHook => write!(f, "missing hook"),
+            MissingPriority => write!(f, "missing priority"),
+            InvalidCombination => write!(f, "invalid combination of chain type, family, and hook"),
+            InvalidPriority => write!(f, "invalid priority value"),
         }
     }
+}
 
-    /// Set the type of a base chain. This only applies if the chain has been registered
-    /// with a hook by calling `set_hook`.
-    pub fn set_type(&mut self, chain_type: ChainType) {
+impl std::error::Error for BaseChainError {}
+
+impl<'a> BaseChainSetter<'a> {
+    /// Create a new base chain setter.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configure the chain type. This is mandatory for a base chain.
+    pub fn chain_type(mut self, chain_type: ChainType) -> Self {
+        self.chain_type = Some(chain_type);
+        self
+    }
+
+    /// Configure the hook. This is mandatory for a base chain.
+    pub fn hook(mut self, hook: Hook) -> Self {
+        self.hook = Some(hook);
+        self
+    }
+
+    /// Configure the priority. This is mandatory for a base chain.
+    pub fn priority(mut self, priority: Priority) -> Self {
+        self.priority = Some(priority);
+        self
+    }
+
+    /// Configure the device. This is optional.
+    pub fn device<T: AsRef<CStr>>(mut self, device: Option<&'a T>) -> Self {
+        self.device = device.map(AsRef::as_ref);
+        self
+    }
+
+    /// Configure the policy. This is optional.
+    pub fn policy(mut self, policy: Option<Policy>) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Try to set `chain` as the configured base chain.
+    ///
+    /// If the base chain configuration is valid, the chain will be set and the function will return `Ok(())`.
+    /// Otherwise, no operation will be performed and the error will be returned as `Err(BaseChainError)`.
+    ///
+    /// ```
+    /// use nftnl::*;
+    /// use std::ffi::CString;
+    ///
+    /// let table_name = CString::new("test-table").unwrap();
+    /// let chain_name = CString::new("test-chain").unwrap();
+    /// let table = Table::new(&table_name, ProtoFamily::Inet);
+    /// let mut chain = Chain::new(&chain_name, &table);
+    ///
+    /// let setter = BaseChainSetter::new()
+    ///    .chain_type(ChainType::Nat)
+    ///    .hook(Hook::PreRouting)
+    ///    .priority(Priority::Integral(0));
+    ///
+    /// let result = setter.try_set(&mut chain);
+    ///
+    /// assert_eq!(result, Ok(()));
+    ///
+    /// // setter can be reused and modified
+    /// let setter = setter.hook(Hook::Forward);
+    /// let result = setter.try_set(&mut chain);
+    ///
+    /// assert_eq!(result, Err(BaseChainError::InvalidCombination));
+    /// ```
+    pub fn try_set(&self, chain: &mut Chain<'_>) -> Result<(), BaseChainError> {
+        use BaseChainError::*;
+        let Self {
+            chain_type,
+            hook,
+            priority,
+            device,
+            policy,
+        } = self;
+        let Chain { chain, table } = *chain;
+
+        // "For base chains, type, hook and priority parameters are mandatory."
+        if chain_type.is_none() {
+            return Err(MissingChainType);
+        }
+        if hook.is_none() {
+            return Err(MissingHook);
+        }
+        if priority.is_none() {
+            return Err(MissingPriority);
+        }
+
+        let (chain_type, hook, priority) = (chain_type.unwrap(), hook.unwrap(), priority.unwrap());
+        let family = table.get_family();
+
+        {
+            use ChainType::*;
+            use Hook::*;
+            use ProtoFamily::*;
+
+            // nft manpage Table 5
+            // FIXME: add missing netdev ingress/egress hooks
+            match (chain_type, family, hook) {
+                (Filter, Arp, In | Out) => (),
+                (Filter, Arp, _) => return Err(InvalidCombination),
+                (Filter, _, _) => (),
+                (Nat, Inet | Ipv4 | Ipv6, PreRouting | In | Out | PostRouting) => (),
+                // Inet not documented
+                (Route, Inet | Ipv4 | Ipv6, Out) => (),
+                _ => return Err(InvalidCombination),
+            };
+        }
+
+        let Some(priority) = priority.value(family, hook) else {
+            return Err(InvalidPriority);
+        };
+
+        // "there's a lower excluding limit of -200 for priority values,
+        //  because conntrack hooks at this priority and NAT requires it"
+        if chain_type == ChainType::Nat && priority <= -200 {
+            return Err(InvalidPriority);
+        }
+
         unsafe {
             sys::nftnl_chain_set_str(
-                self.chain,
+                chain,
                 sys::NFTNL_CHAIN_TYPE as u16,
-                chain_type.as_c_str().as_ptr() as *const c_char,
+                chain_type.as_c_str().as_ptr(),
             );
-        }
-    }
 
-    /// Sets the default policy for this chain. That means what action netfilter will apply to
-    /// packets processed by this chain, but that did not match any rules in it.
-    pub fn set_policy(&mut self, policy: Policy) {
-        unsafe {
-            sys::nftnl_chain_set_u32(self.chain, sys::NFTNL_CHAIN_POLICY as u16, policy as u32);
-        }
-    }
+            sys::nftnl_chain_set_u32(chain, sys::NFTNL_CHAIN_HOOKNUM as u16, hook as u32);
 
+            sys::nftnl_chain_set_s32(chain, sys::NFTNL_CHAIN_PRIO as u16, priority);
+
+            if let Some(device) = device {
+                sys::nftnl_chain_set_str(chain, sys::NFTNL_CHAIN_DEV as u16, device.as_ptr());
+            }
+
+            if let Some(policy) = policy {
+                sys::nftnl_chain_set_u32(chain, sys::NFTNL_CHAIN_POLICY as u16, *policy as u32);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Chain<'a> {
     /// Returns the name of this chain.
     pub fn get_name(&self) -> &CStr {
         unsafe {
@@ -142,12 +359,15 @@ impl<'a> Chain<'a> {
     }
 
     /// Returns a reference to the [`Table`] this chain belongs to
-    ///
-    /// [`Table`]: struct.Table.html
     pub fn get_table(&self) -> &Table {
         self.table
     }
 }
+
+// Safety: It should be safe to pass this around and *read* from it
+// from multiple threads
+unsafe impl<'a> Send for Chain<'a> {}
+unsafe impl<'a> Sync for Chain<'a> {}
 
 impl<'a> fmt::Debug for Chain<'a> {
     /// Return a string representation of the chain.

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -62,7 +62,7 @@ pub mod table;
 pub use table::Table;
 
 mod chain;
-pub use chain::{Chain, ChainType, Hook, Policy, Priority};
+pub use chain::{BaseChainSetter, BaseChainError, Chain, ChainType, Hook, Policy, Priority, PriorityName};
 
 mod rule;
 pub use rule::Rule;

--- a/nftnl/src/table.rs
+++ b/nftnl/src/table.rs
@@ -22,7 +22,7 @@ unsafe impl Sync for Table {}
 
 impl Table {
     /// Creates a new table instance with the given name and protocol family.
-    pub fn new<T: AsRef<CStr>>(name: &T, family: ProtoFamily) -> Table {
+    pub fn new<T: AsRef<CStr>>(name: T, family: ProtoFamily) -> Table {
         unsafe {
             let table = try_alloc!(sys::nftnl_table_alloc());
 


### PR DESCRIPTION
As explained in the doc comments, this adds multiple checks to ensure that the base chains are in fact valid to set. Currently, the `set_hook` and `set_type` are separate and cannot check compatibility as a whole. This PR aims to forbid setting any invalid base chain, as defined in the nftables [documentation](https://www.netfilter.org/projects/nftables/manpage.html), to provide greater safety and prevent UB. This is achieved through the `BaseChainSetter`, which is reusable and modifiable.

Example:

```rust
let setter = BaseChainSetter::new()
   .chain_type(ChainType::Nat)
   .hook(Hook::PreRouting)
   .priority(Priority::Integral(0));

let result = setter.try_set(&mut chain);

assert_eq!(result, Ok(()));

let setter = setter.hook(Hook::Forward);
let result = setter.try_set(&mut chain);

// NAT type **cannot** be used with forward hook, hence failed with `InvalidCombination`.
assert_eq!(result, Err(BaseChainError::InvalidCombination));
```

It also adds related error type `BaseChainError` and named/offset priority `Priority`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/64)
<!-- Reviewable:end -->
