### PR TITLE
Upgrade bitflags dependency to latest (2.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Upgrade crates to Rust 2021 edition.
 
+### Removed
+- Remove `Ord` and `PartialOrd` implementation on `States` and `ConntrackStatus`.
+
 
 ## [0.6.2] - 2022-02-11
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -20,7 +20,7 @@ nftnl-1-1-1 = ["nftnl-sys/nftnl-1-1-1"]
 nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 
 [dependencies]
-bitflags = "1.0.4"
+bitflags = "2.6.0"
 log = "0.4"
 nftnl-sys = { path = "../nftnl-sys", version = "0.6.1" }
 

--- a/nftnl/src/expr/ct.rs
+++ b/nftnl/src/expr/ct.rs
@@ -3,6 +3,7 @@ use nftnl_sys::{self as sys, libc};
 use std::os::raw::c_char;
 
 bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct States: u32 {
         const INVALID = 1;
         const ESTABLISHED = 2;
@@ -13,6 +14,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ConntrackStatus: u32 {
         const EXPECTED = 1;
         const SEEN_REPLY = 2;


### PR DESCRIPTION
Just a nice cleanup, adopting latest `bitflags`. Not much changes in practice. One thing is that with bitflags 2 all the traits are not automatically implemented, so one has to do that explicitly. I list all traits that the old enums implemented except `Ord` and `PartialOrd`. I don't think it makes much sense to "order" instances of bitflags? What does that even mean? All the other traits I do think make sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/66)
<!-- Reviewable:end -->
