### PR TITLE
Use `u16::MAX` associated constant instead of from `std::u16`

### DIFF
--- a/nftnl/examples/filter-ethernet.rs
+++ b/nftnl/examples/filter-ethernet.rs
@@ -74,7 +74,7 @@ fn main() -> io::Result<()> {
     // Load a pseudo-random 32 bit unsigned integer into the netfilter register.
     random_rule.add_expr(&nft_expr!(meta random));
     // Check if the random integer is larger than `u32::MAX/2`, thus having 50% chance of success.
-    random_rule.add_expr(&nft_expr!(cmp > (::std::u32::MAX / 2).to_be()));
+    random_rule.add_expr(&nft_expr!(cmp > (u32::MAX / 2).to_be()));
 
     // Add a second counter. This will only be incremented for the packets passing the random check.
     random_rule.add_expr(&nft_expr!(counter));


### PR DESCRIPTION
What a surprise that we still used these! I was part of pushing for adding these as associated constants many years ago :D Apparently clippy recently gained this lint (?). Anyway, easy fix!

Follow up to #65 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/67)
<!-- Reviewable:end -->
