### PR TITLE
Improve documentation on DOCS_RS workaround

### DIFF
--- a/nftnl-sys/build.rs
+++ b/nftnl-sys/build.rs
@@ -26,7 +26,9 @@ fn get_env(var: &'static str) -> Option<PathBuf> {
 }
 
 fn main() {
-    // Do NOT link when building documentation on docs.rs
+    // Do NOT link when building documentation on docs.rs. The native libraries are not
+    // present on their build machines and just makes the compilation fail. Documentation
+    // generation will work without linking.
     if std::env::var("DOCS_RS").is_ok() {
         return;
     }


### PR DESCRIPTION
I just merged #63. This is a nice addition, since currently docs.rs does not have any docs for these crates. However, I felt like the docs around it could be improved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/68)
<!-- Reviewable:end -->
