### PR TITLE
Prepare release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+## [0.7.0] - 2024-09-19
 ### Added
 - Implement `Default` for `nftnl::batch::Batch`.
 - Add support for Raw payload expressions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "ipnetwork",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "nftnl-sys"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cfg-if",
  "libc",

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl-sys"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Mullvad VPN"]
 license = "MIT OR Apache-2.0"
 description = "Low level FFI bindings to libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Mullvad VPN"]
 license = "MIT OR Apache-2.0"
 description = "Safe abstraction for libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"
@@ -22,7 +22,7 @@ nftnl-1-1-2 = ["nftnl-sys/nftnl-1-1-2"]
 [dependencies]
 bitflags = "2.6.0"
 log = "0.4"
-nftnl-sys = { path = "../nftnl-sys", version = "0.6.1" }
+nftnl-sys = { path = "../nftnl-sys", version = "0.6.2" }
 
 [dev-dependencies]
 ipnetwork = "0.20.0"


### PR DESCRIPTION
This PR bumps the version of `ntfnl` and `nftnl-sys` in preparation of a new release.

# TODO
- [x] Await https://github.com/mullvad/nftnl-rs/pull/69 to be merged
- [x] Decide if we should bump the major version or not. If not, either make a release without https://github.com/mullvad/nftnl-rs/pull/66/ or derive `PartialOrd` and `Ord` for `States` and `ConntrackStatus` once again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/70)
<!-- Reviewable:end -->
