### PR TITLE
Convert a bunch of lifetimes to '_ due to clippy now recommending this

### DIFF
--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -174,8 +174,8 @@ pub struct Iter<'a> {
 
 // Safety: It should be safe to pass this around and *read* from it
 // from multiple threads.
-unsafe impl<'a> Send for Iter<'a> {}
-unsafe impl<'a> Sync for Iter<'a> {}
+unsafe impl Send for Iter<'_> {}
+unsafe impl Sync for Iter<'_> {}
 
 impl<'a> Iterator for Iter<'a> {
     type Item = &'a [u8];

--- a/nftnl/src/chain.rs
+++ b/nftnl/src/chain.rs
@@ -74,8 +74,8 @@ pub struct Chain<'a> {
 
 // Safety: It should be safe to pass this around and *read* from it
 // from multiple threads
-unsafe impl<'a> Send for Chain<'a> {}
-unsafe impl<'a> Sync for Chain<'a> {}
+unsafe impl Send for Chain<'_> {}
+unsafe impl Sync for Chain<'_> {}
 
 impl<'a> Chain<'a> {
     /// Creates a new chain instance inside the given [`Table`] and with the given name.
@@ -149,7 +149,7 @@ impl<'a> Chain<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Chain<'a> {
+impl fmt::Debug for Chain<'_> {
     /// Return a string representation of the chain.
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buffer: [u8; 4096] = [0; 4096];
@@ -167,7 +167,7 @@ impl<'a> fmt::Debug for Chain<'a> {
     }
 }
 
-unsafe impl<'a> crate::NlMsg for Chain<'a> {
+unsafe impl crate::NlMsg for Chain<'_> {
     unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
         let raw_msg_type = match msg_type {
             MsgType::Add => libc::NFT_MSG_NEWCHAIN,
@@ -188,7 +188,7 @@ unsafe impl<'a> crate::NlMsg for Chain<'a> {
     }
 }
 
-impl<'a> Drop for Chain<'a> {
+impl Drop for Chain<'_> {
     fn drop(&mut self) {
         unsafe { sys::nftnl_chain_free(self.chain) };
     }

--- a/nftnl/src/expr/cmp.rs
+++ b/nftnl/src/expr/cmp.rs
@@ -117,13 +117,13 @@ impl ToSlice for [u8; 0] {
     }
 }
 
-impl<'a> ToSlice for &'a [u8] {
+impl ToSlice for &'_ [u8] {
     fn to_slice(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self)
     }
 }
 
-impl<'a> ToSlice for &'a [u16] {
+impl ToSlice for &'_ [u16] {
     fn to_slice(&self) -> Cow<'_, [u8]> {
         let ptr = self.as_ptr() as *const u8;
         let len = self.len() * 2;
@@ -186,7 +186,7 @@ impl ToSlice for i32 {
     }
 }
 
-impl<'a> ToSlice for &'a str {
+impl ToSlice for &'_ str {
     fn to_slice(&self) -> Cow<'_, [u8]> {
         Cow::from(self.as_bytes())
     }
@@ -218,7 +218,7 @@ impl ToSlice for InterfaceName {
     }
 }
 
-impl<'a> ToSlice for &'a InterfaceName {
+impl ToSlice for &'_ InterfaceName {
     fn to_slice(&self) -> Cow<'_, [u8]> {
         let bytes = match *self {
             InterfaceName::Exact(ref name) => name.as_bytes_with_nul(),

--- a/nftnl/src/rule.rs
+++ b/nftnl/src/rule.rs
@@ -11,8 +11,8 @@ pub struct Rule<'a> {
 
 // Safety: It should be safe to pass this around and *read* from it
 // from multiple threads
-unsafe impl<'a> Send for Rule<'a> {}
-unsafe impl<'a> Sync for Rule<'a> {}
+unsafe impl Send for Rule<'_> {}
+unsafe impl Sync for Rule<'_> {}
 
 impl<'a> Rule<'a> {
     /// Creates a new rule object in the given [`Chain`].
@@ -70,7 +70,7 @@ impl<'a> Rule<'a> {
     }
 }
 
-unsafe impl<'a> crate::NlMsg for Rule<'a> {
+unsafe impl crate::NlMsg for Rule<'_> {
     unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
         let type_ = match msg_type {
             MsgType::Add => libc::NFT_MSG_NEWRULE,
@@ -91,7 +91,7 @@ unsafe impl<'a> crate::NlMsg for Rule<'a> {
     }
 }
 
-impl<'a> Drop for Rule<'a> {
+impl Drop for Rule<'_> {
     fn drop(&mut self) {
         unsafe { sys::nftnl_rule_free(self.rule) };
     }

--- a/nftnl/src/set.rs
+++ b/nftnl/src/set.rs
@@ -106,7 +106,7 @@ impl<'a, K> Set<'a, K> {
     }
 }
 
-unsafe impl<'a, K> crate::NlMsg for Set<'a, K> {
+unsafe impl<K> crate::NlMsg for Set<'_, K> {
     unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
         let type_ = match msg_type {
             MsgType::Add => libc::NFT_MSG_NEWSET,
@@ -123,7 +123,7 @@ unsafe impl<'a, K> crate::NlMsg for Set<'a, K> {
     }
 }
 
-impl<'a, K> Drop for Set<'a, K> {
+impl<K> Drop for Set<'_, K> {
     fn drop(&mut self) {
         unsafe { sys::nftnl_set_free(self.set) };
     }
@@ -164,7 +164,7 @@ impl<'a, K: 'a> Iterator for SetElemsIter<'a, K> {
     }
 }
 
-impl<'a, K> Drop for SetElemsIter<'a, K> {
+impl<K> Drop for SetElemsIter<'_, K> {
     fn drop(&mut self) {
         unsafe { sys::nftnl_set_elems_iter_destroy(self.iter) };
     }
@@ -176,7 +176,7 @@ pub struct SetElemsMsg<'a, K> {
     ret: Rc<Cell<i32>>,
 }
 
-unsafe impl<'a, K> crate::NlMsg for SetElemsMsg<'a, K> {
+unsafe impl<K> crate::NlMsg for SetElemsMsg<'_, K> {
     unsafe fn write(&self, buf: *mut c_void, seq: u32, msg_type: MsgType) {
         trace!("Writing SetElemsMsg to NlMsg");
         let (type_, flags) = match msg_type {


### PR DESCRIPTION
Clippy now suggest eliding lifetimes where possible. This currently blocks #71 from having a clean CI run so I went ahead and made the fix.

Here you can see a run with the failures: https://github.com/mullvad/nftnl-rs/actions/runs/12828434730/job/35778279138?pr=71

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/72)
<!-- Reviewable:end -->
