### PR TITLE
Add `links` manifest key to `nftnl-sys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Specify `links` manifest key `nftnl-sys`. This allows dependants to pass custom build flags.
 
 
 ## [0.7.0] - 2024-09-19

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["nftables", "nft", "firewall", "iptables", "netfilter"]
 categories = ["network-programming", "os::unix-apis", "external-ffi-bindings", "no-std"]
 edition = "2021"
 rust-version = "1.63.0"
+links = "nftnl"
 
 
 [features]


### PR DESCRIPTION
This PR adds the [`links` manifest key](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) to `nftnl-sys`, effectively allowing users to bypass `nftnl-sys/build.rs`, setting their own compiler flags and [passing the required metadata ahead-of-time](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts). Cargo will also know statically that `nftnl-sys` links against `libnftnl`. I don't know what that information is used for however, other than documentation ¯\\_(ツ)_/¯

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/77)
<!-- Reviewable:end -->
