### PR TITLE
Fix `nftnl-sys` manually linking `libmnl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "mnl-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9750685b201e1ecfaaf7aa5d0387829170fa565989cc481b49080aa155f70457"
+checksum = "a0f3c607af12ed53f3cade8ee7adeced5533800abc0b07f5b6bdc7081d1e0d4c"
 dependencies = [
  "libc",
  "pkg-config",
@@ -73,6 +73,7 @@ version = "0.6.2"
 dependencies = [
  "cfg-if",
  "libc",
+ "mnl-sys",
  "pkg-config",
 ]
 

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -24,6 +24,7 @@ nftnl-1-1-2 = ["nftnl-1-1-1"]
 [dependencies]
 cfg-if = "1.0"
 libc = "0.2.166"
+mnl-sys = "0.2.2" # Find and link `libmnl`
 
 [build-dependencies]
 cfg-if = "1.0"

--- a/nftnl-sys/README.md
+++ b/nftnl-sys/README.md
@@ -7,10 +7,22 @@ See [`nftnl`] for a higher level safe abstraction.
 
 ## Linking to libmnl and libnftnl
 
+### `pkg-config`
 By default this crate uses pkg-config to find and link to its C dependencies, [`libmnl`] and
-[`libnftnl`]. To manually configure where to look for these libraries, set the environment
+[`libnftnl`].
+
+### Manually
+To manually configure where to look for these libraries, either set the environment
 variables `LIBMNL_LIB_DIR` and `LIBNFTNL_LIB_DIR` to point to the directories where `libmnl.so`
-(or `libmnl.a`) and `libnftnl.so` (or `libnftnl.a`) reside.
+(or `libmnl.a`) and `libnftnl.so` (or `libnftnl.a`) reside, or [`override the build script`] to
+manually set the linker directives for both `nftnl` and `mnl`:
+
+```toml
+# .cargo/config.toml
+[target.x86_64-unknown-linux-gnu.nftnl]
+rustc-link-lib = ["nftnl", "mnl"]
+rustc-link-search = ["<type>=<path-to-libnftnl>", "<type>=<path-to-libmnl>"]
+```
 
 ## Selecting version of `libnftnl`
 
@@ -31,5 +43,6 @@ nftnl-sys = { version = "0.1", features = ["nftnl-1-0-9"] }
 [`libmnl`]: https://netfilter.org/projects/libmnl/
 [`nftnl`]: https://crates.io/crates/nftnl
 [`bindgen`]: https://crates.io/crates/bindgen
+[`override the build script`]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts
 
 License: MIT/Apache-2.0

--- a/nftnl-sys/build.rs
+++ b/nftnl-sys/build.rs
@@ -50,21 +50,4 @@ fn main() {
             .probe("libnftnl")
             .unwrap();
     }
-
-    if let Some(lib_dir) = get_env("LIBMNL_LIB_DIR") {
-        if !lib_dir.is_dir() {
-            panic!(
-                "libmnl library directory does not exist: {}",
-                lib_dir.display()
-            );
-        }
-        println!("cargo:rustc-link-search=native={}", lib_dir.display());
-        println!("cargo:rustc-link-lib=mnl");
-    } else {
-        // Trying with pkg-config instead
-        pkg_config::Config::new()
-            .atleast_version("1.0.0")
-            .probe("libmnl")
-            .unwrap();
-    }
 }


### PR DESCRIPTION
Depend on `mnl-sys` to resolve the `libmnl` dependency at build-time instead of manually setting `rustc-link-lib` for `libmnl` in `nftnl-sys`. This change depends on https://github.com/mullvad/mnl-rs/pull/16, so a new release of `mnl-sys` needs to be cut before this can be merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/78)
<!-- Reviewable:end -->
