### PR TITLE
Update changelog to mention support for ingress hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add support for ingress hooks. Corresponds to `NF_INET_INGRESS`.
 - Specify `links` manifest key `nftnl-sys`. This allows dependants to pass custom build flags.
+
+### Changed
+- Bump MSRV to 1.63.0 for `nftnl` and `nftnl-sys`.
 
 
 ## [0.7.0] - 2024-09-19


### PR DESCRIPTION
This PR mentions https://github.com/mullvad/nftnl-rs/pull/71 in the changelog.

- Bump MSRV to 1.63
- Add support for ingress hooks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/79)
<!-- Reviewable:end -->
