### PR TITLE
Panic if Batch::with_page_size would overflow

### DIFF
--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -53,7 +53,14 @@ impl Batch {
     }
 
     /// Creates a new nftnl batch with the given batch size.
+    ///
+    /// # Panics
+    /// Panics if `batch_page_size + nft_nlmsg_maxsize` would overflow.
     pub fn with_page_size(batch_page_size: u32) -> Self {
+        batch_page_size
+            .checked_add(crate::nft_nlmsg_maxsize())
+            .expect("batch_page_size is too large and would overflow");
+
         let batch = try_alloc!(unsafe {
             sys::nftnl_batch_alloc(batch_page_size, crate::nft_nlmsg_maxsize())
         });


### PR DESCRIPTION
fixes #76

The issue stems from an addition here:
https://git.netfilter.org/libnftnl/tree/src/batch.c#n33

Passing a very large value to `with_page_size` would cause the addition to overflow, and the allocation would instead be very small, causing a heap overflow.

It's such a niche case that proper error handling is not worth it imho.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/82)
<!-- Reviewable:end -->
