### PR TITLE
Prepare release `0.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upgrade to rust edition 2024
+- Expose message sequence numbers from batch.
 
 ### Fixed
 - Fix buffer-overflow in `Batch::with_page_size` due to insufficient allocation for malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix buffer-overflow in `Batch::with_page_size` due to insufficient allocation for malformed
   page sizes. Panic in these cases instead.
+- Fix endianess in `ToSlice` implementations for integer types by using native endianess instead
+  of assuming little endian.
 
 ### Removed
 - Remove `ToSlice` implementation for `&str` in favor of `&CStr`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix buffer-overflow in `Batch::with_page_size` due to insufficient allocation for malformed
   page sizes. Panic in these cases instead.
 
+### Removed
+- Remove `ToSlice` implementation for `&str` in favor of `&CStr`.
+
 
 ## [0.8.0] - 2025-10-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Generate bindings for libnftnl 1.0.3 through 1.3.0
 - Add support for Socket expressions.
 - Implement `ToSlice` for `u64`.
+- Implement `ToSlice` for `&CStr`.
 
 ### Changed
 - Upgrade to rust edition 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Generate bindings for libnftnl 1.0.3 through 1.3.0
 - Add support for Socket expressions.
+- Implement `ToSlice` for `u64`.
 
 ### Changed
 - Upgrade to rust edition 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Upgrade to rust edition 2024
 
+### Fixed
+- Fix buffer-overflow in `Batch::with_page_size` due to insufficient allocation for malformed
+  page sizes. Panic in these cases instead.
+
+
 ## [0.8.0] - 2025-10-30
 ### Added
 - Add support for ingress hooks. Corresponds to `NF_INET_INGRESS`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Generate bindings for libnftnl 1.0.3 through 1.3.0
+- Generate bindings for libnftnl 1.0.3 through 1.3.0.
 - Add support for Socket expressions.
 - Implement `ToSlice` for `u64`.
 - Implement `ToSlice` for `&CStr`.
 
 ### Changed
-- Upgrade to rust edition 2024
+- Upgrade to rust edition 2024.
 - Expose message sequence numbers from batch.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "nftnl-sys"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "ipnetwork",

--- a/nftnl-sys/Cargo.toml
+++ b/nftnl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl-sys"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Mullvad VPN"]
 license = "MIT OR Apache-2.0"
 description = "Low level FFI bindings to libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nftnl"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Mullvad VPN"]
 license = "MIT OR Apache-2.0"
 description = "Safe abstraction for libnftnl. Provides low-level userspace access to the in-kernel nf_tables subsystem"


### PR DESCRIPTION
Prepare to release `0.9.0` with the following changes.

```
### Added
- Generate bindings for libnftnl 1.0.3 through 1.3.0.
- Add support for Socket expressions.
- Implement `ToSlice` for `u64`.
- Implement `ToSlice` for `&CStr`.

### Changed
- Upgrade to rust edition 2024.
- Expose message sequence numbers from batch.

### Fixed
- Fix buffer-overflow in `Batch::with_page_size` due to insufficient allocation for malformed
  page sizes. Panic in these cases instead.
- Fix endianess in `ToSlice` implementations for integer types by using native endianess instead
  of assuming little endian.

### Removed
- Remove `ToSlice` implementation for `&str` in favor of `&CStr`.
```
This release is breaking due to switching Rust edition from 2021 to 2024 and removing `ToSlice for &str`.

### TODO
- Decide if https://github.com/mullvad/nftnl-rs/pull/86 should be included in `0.9.0` or in a patch release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/87)
<!-- Reviewable:end -->
