### PR TITLE
Release `nftnl 0.9.0` and `nftnl-sys 0.6.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+## [0.9.0] - 2025-11-26
 ### Added
 - Generate bindings for libnftnl 1.0.3 through 1.3.0.
 - Add support for Socket expressions.


### PR DESCRIPTION
Release has already been published on [crates.io](https://crates.io/crates/nftnl), and a signed tag has already been pushed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/88)
<!-- Reviewable:end -->
