### PR TITLE
Set NLM_F_ACK on kernel versions that support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Avoid raising `NLM_F_ACK` for batch start/end messages on kernel version prior to 6.10.
 
 ## [0.9.0] - 2025-11-26
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +71,7 @@ dependencies = [
  "log",
  "mnl",
  "nftnl-sys",
+ "nix",
 ]
 
 [[package]]
@@ -75,6 +82,18 @@ dependencies = [
  "libc",
  "mnl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/nftnl/Cargo.toml
+++ b/nftnl/Cargo.toml
@@ -43,6 +43,7 @@ log = "0.4"
 
 # NOTE: keep version in lock-step with build-dependency
 nftnl-sys = { path = "../nftnl-sys", version = "0.6.2" }
+nix = { version = "0.30.1", features = ["feature"] }
 
 [build-dependencies]
 nftnl-sys = { path = "../nftnl-sys", version = "0.6.2" }

--- a/nftnl/src/batch.rs
+++ b/nftnl/src/batch.rs
@@ -1,10 +1,13 @@
+use crate::util::KERNEL_VERSION;
 use crate::{MsgType, NlMsg};
 use core::fmt;
 use nftnl_sys::{self as sys, libc};
+use nix::libc::{NLM_F_ACK, nlmsghdr};
 use std::ffi::c_void;
 use std::ops::Range;
 use std::os::raw::c_char;
 use std::ptr;
+use std::sync::LazyLock;
 
 /// Error while communicating with netlink
 #[derive(Debug)]
@@ -15,6 +18,20 @@ impl fmt::Display for NetlinkError {
         "Error while communicating with netlink".fmt(f)
     }
 }
+
+/// Whether we should set `F_ACK` for batch start/end messages.
+pub static ACK_BATCH_END_MESSAGES: LazyLock<bool> = LazyLock::new(|| {
+    let Some(kernel_version) = *KERNEL_VERSION else {
+        if cfg!(debug_assertions) {
+            panic!("Failed to parse kernel version");
+        } else {
+            return true;
+        }
+    };
+
+    // The kernel didn't respect the F_ACK flag for netlink nft batch messages until 6.10
+    kernel_version >= (6, 10)
+});
 
 impl std::error::Error for NetlinkError {}
 
@@ -114,19 +131,52 @@ impl Batch {
     }
 
     fn write_begin_msg(&mut self) {
-        unsafe { sys::nftnl_batch_begin(self.current().cast::<c_char>(), self.seqs.end) };
-        self.next();
+        unsafe { self.write_begin_or_end_msg(sys::nftnl_batch_begin) }
     }
 
     fn write_end_msg(&mut self) {
-        unsafe { sys::nftnl_batch_end(self.current().cast::<c_char>(), self.seqs.end) };
-        self.next();
+        unsafe { self.write_begin_or_end_msg(sys::nftnl_batch_end) }
+    }
+
+    unsafe fn write_begin_or_end_msg(
+        &mut self,
+        f: unsafe extern "C" fn(*mut c_char, u32) -> *mut nlmsghdr,
+    ) {
+        let buf_ptr = self.current().cast::<c_char>();
+
+        // We only set F_ACK (and a sequence number) if the kernel supports it.
+        let kernel_supports_ack = *ACK_BATCH_END_MESSAGES;
+        let seq = if kernel_supports_ack {
+            self.seqs.end
+        } else {
+            0 // don't check sequence number
+        };
+
+        // Construct the header
+        let header = unsafe { f(buf_ptr, seq) };
+
+        // Raise F_ACK
+        if kernel_supports_ack {
+            unsafe { set_f_ack(header) };
+            self.seqs.end += 1;
+        }
+
+        if unsafe { sys::nftnl_batch_update(self.batch.as_ptr()) } < 0 {
+            // See try_alloc definition.
+            std::process::abort();
+        }
     }
 
     /// Returns the underlying `nftnl_batch` instance.
     pub fn as_raw_batch(&self) -> ptr::NonNull<sys::nftnl_batch> {
         self.batch
     }
+}
+
+/// Set the [`NLM_F_ACK`] flag on the netlink message.
+unsafe fn set_f_ack(header: *mut libc::nlmsghdr) {
+    let mut header = ptr::NonNull::new(header).expect("nlmsg_build_hdr never returns null");
+    unsafe { header.as_mut() }.nlmsg_flags |= NLM_F_ACK as u16;
 }
 
 impl Drop for Batch {
@@ -169,8 +219,7 @@ impl FinalizedBatch {
 
     /// Returns the range of sequence numbers for the messages in this batch that expect an ACK.
     pub fn sequence_numbers(&self) -> Range<u32> {
-        // The first (BATCH_BEGIN) and last (BATCH_END) messages do not expect an ACK.
-        (self.batch.seqs.start + 1)..(self.batch.seqs.end - 1)
+        self.batch.seqs.clone()
     }
 }
 

--- a/nftnl/src/lib.rs
+++ b/nftnl/src/lib.rs
@@ -53,6 +53,8 @@ macro_rules! try_alloc {
     }};
 }
 
+mod util;
+
 mod batch;
 pub use batch::{Batch, FinalizedBatch, NetlinkError, batch_is_supported, default_batch_page_size};
 

--- a/nftnl/src/util.rs
+++ b/nftnl/src/util.rs
@@ -1,0 +1,17 @@
+use std::sync::LazyLock;
+
+/// Kernel version and major revision, i.e. the first two numbers of e.g. "6.6.9-foo-1"
+pub static KERNEL_VERSION: LazyLock<Option<(u32, u32)>> = LazyLock::new(|| {
+    // parse kernel version from uname based on this "specification":
+    // https://www.linfo.org/kernel_version_numbering.html
+
+    let uname = nix::sys::utsname::uname().ok()?;
+    let release = uname.release().to_str()?;
+    let (kernel_version, release) = release.split_once('.')?;
+    let (major_revision, _) = release.split_once('.')?;
+
+    let kernel_version = kernel_version.parse().ok()?;
+    let major_revision = major_revision.parse().ok()?;
+
+    Some((kernel_version, major_revision))
+});


### PR DESCRIPTION
Setting NLM_F_ACK on batch end makes handling errors on that message much easier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/nftnl-rs/91)
<!-- Reviewable:end -->
